### PR TITLE
upgrade ksqldb version due to maven dependency resolution errors

### DIFF
--- a/ksqldb-udfs-kryptonite/pom.xml
+++ b/ksqldb-udfs-kryptonite/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <kryptonite.version>0.5.0</kryptonite.version>
-        <ksql.version>7.5.7</ksql.version>
+        <ksql.version>7.5.9</ksql.version>
         <jackson.version>2.18.3</jackson.version>
         <logback.version>1.2.13</logback.version>
         <junit.version>5.10.2</junit.version>


### PR DESCRIPTION
For some reason the previously used ksqldb version stopped working because some transitive dependencies in use couldn't be resolved any longer which is weird. Neither from maven nor from confluent's main / snapshot repos, hence the version change/upgrade for the ksqldb dependency to fix the build errors.