### PR TITLE
Add functional tests for Flink UDFs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Kryptonite for Kafka provides client-side field-level cryptography for Apache Kafka using authenticated encryption (AEAD). It supports encryption/decryption via:
+
+1. **Kafka Connect SMT** - Single Message Transformation for data integration
+2. **ksqlDB UDFs** - User-Defined Functions for stream processing
+3. **Flink UDFs** - User-Defined Functions for Flink Table API/SQL
+4. **Quarkus Funqy HTTP API** - Web service for cross-language scenarios
+
+The cryptographic implementation uses Google's Tink library with AES-GCM (probabilistic) or AES-GCM-SIV (deterministic) modes.
+
+## Build Commands
+
+```bash
+# Build entire project
+./mvnw clean install
+
+# Build specific module
+./mvnw clean install -pl <module-name>
+
+# Run tests for entire project
+./mvnw test
+
+# Run tests for specific module
+./mvnw test -pl <module-name>
+
+# Package without running tests
+./mvnw clean package -DskipTests
+```
+
+## Architecture
+
+**Multi-module Maven project structure:**
+
+- `kryptonite/` - Core cryptography library (shared by all modules)
+- `connect-transform-kryptonite/` - Kafka Connect SMT implementation
+- `ksqldb-udfs-kryptonite/` - ksqlDB user-defined functions
+- `flink-udfs-kryptonite/` - Flink user-defined functions
+- `funqy-http-kryptonite/` - Quarkus-based HTTP API service
+
+**Core library (`kryptonite/`) packages:**
+
+- `com.github.hpgrahsl.kryptonite` - Main entry point (`Kryptonite` class) and field metadata
+- `com.github.hpgrahsl.kryptonite.config` - Configuration handling and keyset management
+- `com.github.hpgrahsl.kryptonite.crypto` - Cryptographic algorithm implementations (Tink-based)
+- `com.github.hpgrahsl.kryptonite.keys` - Key vault abstractions and key material resolution
+- `com.github.hpgrahsl.kryptonite.kms` - Cloud KMS integrations (Azure Key Vault, GCP KMS)
+- `com.github.hpgrahsl.kryptonite.serdes` - Serialization/deserialization (Kryo-based)
+
+**Key architecture concepts:**
+
+1. **Encryption modes**: OBJECT (encrypt entire field) vs ELEMENT (encrypt array/map elements individually)
+2. **Key management**: Supports local config, encrypted keysets, and cloud KMS (Azure, GCP)
+3. **Cipher algorithms**: TINK/AES_GCM (probabilistic), TINK/AES_GCM_SIV (deterministic - use for record keys)
+4. **Encrypted field format**: Base64-encoded string containing ciphertext + authenticated metadata (version, algorithm, keyset ID)
+
+## Important Notes
+
+- **Java 17+** required (see `maven.compiler.release` in pom.xml)
+- **Deterministic encryption**: Use AES-GCM-SIV for Kafka record keys to maintain partitioning
+- **Schema handling**: Encrypted fields are stored as VARCHAR/STRING in schema-aware systems
+- **Keyset security**: Key materials must be treated with utmost secrecy - use external config or cloud KMS
+- **Tink keysets**: All cryptographic key materials must be valid Tink keyset JSON specifications
+
+## Configuration Examples
+
+All modules require keyset configuration. Example Tink keyset structure:
+
+```json
+{
+  "identifier": "my-demo-secret-key-123",
+  "material": {
+    "primaryKeyId": 123456789,
+    "key": [{
+      "keyData": {
+        "typeUrl": "type.googleapis.com/google.crypto.tink.AesGcmKey",
+        "value": "<BASE64_ENCODED_KEY_HERE>",
+        "keyMaterialType": "SYMMETRIC"
+      },
+      "status": "ENABLED",
+      "keyId": 123456789,
+      "outputPrefixType": "TINK"
+    }]
+  }
+}
+```
+
+## Development Workflow
+
+1. Core library changes affect all dependent modules
+2. Module-specific changes are isolated to their respective directories
+3. Each module has its own README.md with detailed usage examples
+4. Pre-built binaries available on GitHub releases page (since v0.4.0)

--- a/flink-udfs-kryptonite/src/test/java/com/github/hpgrahsl/flink/functions/kryptonite/CipherFieldEncryptDecryptUdfFunctionalTest.java
+++ b/flink-udfs-kryptonite/src/test/java/com/github/hpgrahsl/flink/functions/kryptonite/CipherFieldEncryptDecryptUdfFunctionalTest.java
@@ -1,0 +1,451 @@
+/*
+ * Copyright (c) 2025. Hans-Peter Grahsl (grahslhp@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.hpgrahsl.flink.functions.kryptonite;
+
+import com.github.hpgrahsl.kryptonite.Kryptonite;
+import com.github.hpgrahsl.kryptonite.config.KryptoniteSettings;
+import com.github.hpgrahsl.kryptonite.crypto.tink.TinkAesGcm;
+import com.github.hpgrahsl.kryptonite.crypto.tink.TinkAesGcmSiv;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.types.Row;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class CipherFieldEncryptDecryptUdfFunctionalTest {
+
+    enum FieldMode {
+        OBJECT,
+        ELEMENT
+    }
+
+    @Nested
+    class WithoutCloudKmsConfig {
+
+        @ParameterizedTest
+        @MethodSource("com.github.hpgrahsl.flink.functions.kryptonite.CipherFieldEncryptDecryptUdfFunctionalTest#generateValidParamsWithoutCloudKms")
+        @DisplayName("apply UDF on row data in object mode to verify decrypt(encrypt(plaintext)) = plaintext with various param combinations")
+        void encryptDecryptUdfForRow(FieldMode fieldMode, String cipherDataKeys, String defaultKeyIdentifier,
+                String keyIdentifier, Kryptonite.CipherSpec cipherAlgorithm,
+                KryptoniteSettings.KeySource keySource, KryptoniteSettings.KmsType kmsType, String kmsConfig,
+                KryptoniteSettings.KekType kekType, String kekConfig, String kekUri) {
+
+            performTestForRow(fieldMode, cipherDataKeys, defaultKeyIdentifier, keyIdentifier, cipherAlgorithm,
+                                    keySource, kmsType, kmsConfig, kekType, kekConfig, kekUri);
+        }
+
+        @ParameterizedTest
+        @MethodSource("com.github.hpgrahsl.flink.functions.kryptonite.CipherFieldEncryptDecryptUdfFunctionalTest#generateValidParamsWithoutCloudKms")
+        @DisplayName("apply UDF on map data in object mode to verify decrypt(encrypt(plaintext)) = plaintext with various param combinations")
+        void encryptDecryptUdfForMap(FieldMode fieldMode, String cipherDataKeys, String defaultKeyIdentifier,
+                String keyIdentifier, Kryptonite.CipherSpec cipherAlgorithm,
+                KryptoniteSettings.KeySource keySource, KryptoniteSettings.KmsType kmsType, String kmsConfig,
+                KryptoniteSettings.KekType kekType, String kekConfig, String kekUri) {
+
+            performTestForMap(fieldMode, cipherDataKeys, defaultKeyIdentifier, keyIdentifier, cipherAlgorithm,
+                                    keySource, kmsType, kmsConfig, kekType, kekConfig, kekUri);
+        }
+
+    }
+
+    @Nested
+    @EnabledIfSystemProperty(named = "cloud.kms.tests", matches = "true")
+    class WithCloudKmsConfig {
+
+        @ParameterizedTest
+        @MethodSource("com.github.hpgrahsl.flink.functions.kryptonite.CipherFieldEncryptDecryptUdfFunctionalTest#generateValidParamsWithCloudKms")
+        @DisplayName("apply UDF on row data in object mode to verify decrypt(encrypt(plaintext)) = plaintext with various param combinations")
+        void encryptDecryptUdfForRow(FieldMode fieldMode, String cipherDataKeys, String defaultKeyIdentifier,
+                String keyIdentifier, Kryptonite.CipherSpec cipherAlgorithm,
+                KryptoniteSettings.KeySource keySource, KryptoniteSettings.KmsType kmsType, String kmsConfig,
+                KryptoniteSettings.KekType kekType, String kekConfig, String kekUri) {
+
+            performTestForRow(fieldMode, cipherDataKeys, defaultKeyIdentifier, keyIdentifier, cipherAlgorithm,
+                                    keySource, kmsType, kmsConfig, kekType, kekConfig, kekUri);
+        }
+
+        @ParameterizedTest
+        @MethodSource("com.github.hpgrahsl.flink.functions.kryptonite.CipherFieldEncryptDecryptUdfFunctionalTest#generateValidParamsWithCloudKms")
+        @DisplayName("apply UDF on map data in object mode to verify decrypt(encrypt(plaintext)) = plaintext with various param combinations")
+        void encryptDecryptUdfForMap(FieldMode fieldMode, String cipherDataKeys, String defaultKeyIdentifier,
+                String keyIdentifier, Kryptonite.CipherSpec cipherAlgorithm,
+                KryptoniteSettings.KeySource keySource, KryptoniteSettings.KmsType kmsType, String kmsConfig,
+                KryptoniteSettings.KekType kekType, String kekConfig, String kekUri) {
+
+            performTestForMap(fieldMode, cipherDataKeys, defaultKeyIdentifier, keyIdentifier, cipherAlgorithm,
+                                    keySource, kmsType, kmsConfig, kekType, kekConfig, kekUri);
+        }
+
+    }
+
+    static List<Arguments> generateValidParamsWithoutCloudKms() {
+        return List.of(
+                Arguments.of(FieldMode.ELEMENT, TestFixtures.CIPHER_DATA_KEYS_CONFIG, "keyA", "keyB",
+                        Kryptonite.CipherSpec.fromName(TinkAesGcm.CIPHER_ALGORITHM),
+                        KryptoniteSettings.KeySource.CONFIG, KryptoniteSettings.KmsType.NONE, "{}",
+                        KryptoniteSettings.KekType.NONE, "{}", ""),
+                Arguments.of(FieldMode.OBJECT, TestFixtures.CIPHER_DATA_KEYS_CONFIG, "key9", "key8",
+                        Kryptonite.CipherSpec.fromName(TinkAesGcmSiv.CIPHER_ALGORITHM),
+                        KryptoniteSettings.KeySource.CONFIG, KryptoniteSettings.KmsType.NONE, "{}",
+                        KryptoniteSettings.KekType.NONE, "{}", "")
+        );
+    }
+
+    static List<Arguments> generateValidParamsWithCloudKms() throws Exception {
+        var credentials = TestFixturesCloudKms.readCredentials();
+        return List.of(
+                Arguments.of(FieldMode.ELEMENT, TestFixtures.CIPHER_DATA_KEYS_CONFIG_ENCRYPTED, "keyX", "keyY",
+                        Kryptonite.CipherSpec.fromName(TinkAesGcm.CIPHER_ALGORITHM),
+                        KryptoniteSettings.KeySource.CONFIG_ENCRYPTED, KryptoniteSettings.KmsType.NONE, "{}",
+                        KryptoniteSettings.KekType.GCP,
+                        credentials.getProperty("test.kek.config"), credentials.getProperty("test.kek.uri")),
+                Arguments.of(FieldMode.OBJECT, TestFixtures.CIPHER_DATA_KEYS_CONFIG_ENCRYPTED, "key1", "key0",
+                        Kryptonite.CipherSpec.fromName(TinkAesGcmSiv.CIPHER_ALGORITHM),
+                        KryptoniteSettings.KeySource.CONFIG_ENCRYPTED, KryptoniteSettings.KmsType.NONE, "{}",
+                        KryptoniteSettings.KekType.GCP,
+                        credentials.getProperty("test.kek.config"), credentials.getProperty("test.kek.uri")),
+                Arguments.of(FieldMode.ELEMENT, TestFixtures.CIPHER_DATA_KEYS_EMPTY, "keyA", "keyB",
+                        Kryptonite.CipherSpec.fromName(TinkAesGcm.CIPHER_ALGORITHM),
+                        KryptoniteSettings.KeySource.KMS, KryptoniteSettings.KmsType.AZ_KV_SECRETS,
+                        credentials.getProperty("test.kms.config"), KryptoniteSettings.KekType.NONE, "{}", ""),
+                Arguments.of(FieldMode.OBJECT, TestFixtures.CIPHER_DATA_KEYS_EMPTY, "key9", "key8",
+                        Kryptonite.CipherSpec.fromName(TinkAesGcmSiv.CIPHER_ALGORITHM),
+                        KryptoniteSettings.KeySource.KMS, KryptoniteSettings.KmsType.AZ_KV_SECRETS,
+                        credentials.getProperty("test.kms.config"), KryptoniteSettings.KekType.NONE, "{}", ""),
+                Arguments.of(FieldMode.ELEMENT, TestFixtures.CIPHER_DATA_KEYS_EMPTY, "keyX", "keyY",
+                        Kryptonite.CipherSpec.fromName(TinkAesGcm.CIPHER_ALGORITHM),
+                        KryptoniteSettings.KeySource.KMS_ENCRYPTED, KryptoniteSettings.KmsType.AZ_KV_SECRETS,
+                        credentials.getProperty("test.kms.config.encrypted"),
+                        KryptoniteSettings.KekType.GCP, credentials.getProperty("test.kek.config"),
+                        credentials.getProperty("test.kek.uri")),
+                Arguments.of(FieldMode.OBJECT, TestFixtures.CIPHER_DATA_KEYS_EMPTY, "key1", "key0",
+                        Kryptonite.CipherSpec.fromName(TinkAesGcmSiv.CIPHER_ALGORITHM),
+                        KryptoniteSettings.KeySource.KMS_ENCRYPTED, KryptoniteSettings.KmsType.AZ_KV_SECRETS,
+                        credentials.getProperty("test.kms.config.encrypted"),
+                        KryptoniteSettings.KekType.GCP, credentials.getProperty("test.kek.config"),
+                        credentials.getProperty("test.kek.uri"))
+        );
+    }
+
+    void performTestForMap(FieldMode fieldMode, String cipherDataKeys, String defaultKeyIdentifier,
+            String keyIdentifier, Kryptonite.CipherSpec cipherAlgorithm,
+            KryptoniteSettings.KeySource keySource, KryptoniteSettings.KmsType kmsType, String kmsConfig,
+            KryptoniteSettings.KekType kekType, String kekConfig, String kekUri) {
+
+        var cfeUDF = new EncryptUdf();
+        var mockContextEncrypt = createMockFunctionContext(
+                cipherDataKeys, defaultKeyIdentifier, keySource, kmsType, kmsConfig, kekType, kekConfig, kekUri);
+
+        try {
+            cfeUDF.open(mockContextEncrypt);
+        } catch (Exception e) {
+            fail("Failed to open encrypt UDF: " + e.getMessage());
+        }
+
+        Map<String, Object> encryptedData;
+        if (fieldMode == FieldMode.ELEMENT) {
+            encryptedData = TestFixtures.TEST_OBJ_MAP_1.entrySet().stream()
+                    .map(
+                            e -> Map.entry(
+                                    e.getKey(),
+                                    Set.of("mySubDoc1", "myArray1", "mySubDoc2").contains(e.getKey())
+                                            ? encryptComplexFieldElementwise(cfeUDF, e.getValue(), keyIdentifier,
+                                                    cipherAlgorithm.getName())
+                                            : cfeUDF.eval(e.getValue(), keyIdentifier,
+                                                    cipherAlgorithm.getName())))
+                    .collect(LinkedHashMap::new, (lhm, e) -> lhm.put(e.getKey(), e.getValue()), HashMap::putAll);
+
+            assertAll(
+                    () -> assertTrue(encryptedData.get("mySubDoc1") instanceof Map),
+                    () -> assertTrue(encryptedData.get("myArray1") instanceof List),
+                    () -> assertTrue(encryptedData.get("mySubDoc2") instanceof Map));
+        } else {
+            encryptedData = TestFixtures.TEST_OBJ_MAP_1.entrySet().stream()
+                    .map(
+                            e -> Map.entry(
+                                    e.getKey(),
+                                    cfeUDF.eval(e.getValue(), keyIdentifier, cipherAlgorithm.getName())))
+                    .collect(LinkedHashMap::new, (lhm, e) -> lhm.put(e.getKey(), e.getValue()), HashMap::putAll);
+
+            assertAll(
+                    () -> assertEquals(String.class, encryptedData.get("mySubDoc1").getClass()),
+                    () -> assertEquals(String.class, encryptedData.get("myArray1").getClass()),
+                    () -> assertEquals(String.class, encryptedData.get("mySubDoc2").getClass()));
+        }
+
+        var cfdUDF = new DecryptUdf();
+        var mockContextDecrypt = createMockFunctionContext(
+                cipherDataKeys, "", keySource, kmsType, kmsConfig, kekType, kekConfig, kekUri);
+
+        try {
+            cfdUDF.open(mockContextDecrypt);
+        } catch (Exception e) {
+            fail("Failed to open decrypt UDF: " + e.getMessage());
+        }
+
+        Map<String, Object> decryptedData;
+        if (fieldMode == FieldMode.ELEMENT) {
+            decryptedData = encryptedData.entrySet().stream()
+                    .map(
+                            e -> Map.entry(
+                                    e.getKey(),
+                                    Set.of("mySubDoc1", "myArray1", "mySubDoc2").contains(e.getKey())
+                                            ? decryptComplexFieldElementwise(cfdUDF, e.getValue(),
+                                                    TestFixtures.TEST_OBJ_MAP_1.get(e.getKey()))
+                                            : cfdUDF.eval((String) e.getValue(),
+                                                    TestFixtures.TEST_OBJ_MAP_1.get(e.getKey()))))
+                    .collect(LinkedHashMap::new, (lhm, e) -> lhm.put(e.getKey(), e.getValue()), HashMap::putAll);
+        } else {
+            decryptedData = encryptedData.entrySet().stream()
+                    .map(
+                            e -> Map.entry(
+                                    e.getKey(),
+                                    cfdUDF.eval((String) e.getValue(),
+                                            TestFixtures.TEST_OBJ_MAP_1.get(e.getKey()))))
+                    .collect(LinkedHashMap::new, (lhm, e) -> lhm.put(e.getKey(), e.getValue()), HashMap::putAll);
+        }
+
+        assertAllResultingFieldsMapRecord(TestFixtures.TEST_OBJ_MAP_1, decryptedData);
+    }
+
+    void performTestForRow(FieldMode fieldMode, String cipherDataKeys, String defaultKeyIdentifier,
+            String keyIdentifier, Kryptonite.CipherSpec cipherAlgorithm,
+            KryptoniteSettings.KeySource keySource, KryptoniteSettings.KmsType kmsType, String kmsConfig,
+            KryptoniteSettings.KekType kekType, String kekConfig, String kekUri) {
+
+        var cfeUDF = new EncryptUdf();
+        var mockContextEncrypt = createMockFunctionContext(
+                cipherDataKeys, defaultKeyIdentifier, keySource, kmsType, kmsConfig, kekType, kekConfig, kekUri);
+
+        try {
+            cfeUDF.open(mockContextEncrypt);
+        } catch (Exception e) {
+            fail("Failed to open encrypt UDF: " + e.getMessage());
+        }
+
+        Row originalRow = TestFixtures.TEST_OBJ_ROW_1;
+        Object[] encryptedFields = new Object[originalRow.getArity()];
+
+        if (fieldMode == FieldMode.ELEMENT) {
+            for (int i = 0; i < originalRow.getArity(); i++) {
+                Object field = originalRow.getField(i);
+                if (i == 4 || i == 5 || i == 6) { // mySubDoc1, myArray1, mySubDoc2
+                    encryptedFields[i] = encryptComplexFieldElementwise(cfeUDF, field, keyIdentifier,
+                            cipherAlgorithm.getName());
+                } else {
+                    encryptedFields[i] = cfeUDF.eval(field, keyIdentifier, cipherAlgorithm.getName());
+                }
+            }
+
+            assertAll(
+                    () -> assertTrue(encryptedFields[4] instanceof Row),
+                    () -> assertTrue(encryptedFields[5] instanceof String[]),
+                    () -> assertTrue(encryptedFields[6] instanceof Map));
+        } else {
+            for (int i = 0; i < originalRow.getArity(); i++) {
+                encryptedFields[i] = cfeUDF.eval(originalRow.getField(i), keyIdentifier, cipherAlgorithm.getName());
+            }
+
+            assertAll(
+                    () -> assertEquals(String.class, encryptedFields[4].getClass()),
+                    () -> assertEquals(String.class, encryptedFields[5].getClass()),
+                    () -> assertEquals(String.class, encryptedFields[6].getClass()));
+        }
+
+        Row encryptedRow = Row.of(encryptedFields);
+
+        var cfdUDF = new DecryptUdf();
+        var mockContextDecrypt = createMockFunctionContext(
+                cipherDataKeys, "", keySource, kmsType, kmsConfig, kekType, kekConfig, kekUri);
+
+        try {
+            cfdUDF.open(mockContextDecrypt);
+        } catch (Exception e) {
+            fail("Failed to open decrypt UDF: " + e.getMessage());
+        }
+
+        Object[] decryptedFields = new Object[encryptedRow.getArity()];
+        if (fieldMode == FieldMode.ELEMENT) {
+            for (int i = 0; i < encryptedRow.getArity(); i++) {
+                Object encField = encryptedRow.getField(i);
+                Object origField = originalRow.getField(i);
+                if (i == 4 || i == 5 || i == 6) { // mySubDoc1, myArray1, mySubDoc2
+                    decryptedFields[i] = decryptComplexFieldElementwise(cfdUDF, encField, origField);
+                } else {
+                    decryptedFields[i] = cfdUDF.eval((String) encField, origField);
+                }
+            }
+        } else {
+            for (int i = 0; i < encryptedRow.getArity(); i++) {
+                decryptedFields[i] = cfdUDF.eval((String) encryptedRow.getField(i), originalRow.getField(i));
+            }
+        }
+
+        Row decryptedRow = Row.of(decryptedFields);
+        assertAllResultingFieldsRowRecord(originalRow, decryptedRow);
+    }
+
+    @SuppressWarnings("unchecked")
+    Object encryptComplexFieldElementwise(EncryptUdf udf, Object data, String keyId, String algorithm) {
+        // For complex types in ELEMENT mode, encrypt each element individually using the main UDF
+        if (data instanceof String[]) {
+            String[] array = (String[]) data;
+            String[] encryptedArray = new String[array.length];
+            for (int i = 0; i < array.length; i++) {
+                encryptedArray[i] = udf.eval(array[i], keyId, algorithm);
+            }
+            return encryptedArray;
+        }
+        if (data instanceof List) {
+            List<?> list = (List<?>) data;
+            List<String> encryptedList = new ArrayList<>();
+            for (Object item : list) {
+                encryptedList.add(udf.eval(item, keyId, algorithm));
+            }
+            return encryptedList;
+        }
+        if (data instanceof Map) {
+            Map<?, ?> map = (Map<?, ?>) data;
+            Map<Object, String> encryptedMap = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                encryptedMap.put(entry.getKey(), udf.eval(entry.getValue(), keyId, algorithm));
+            }
+            return encryptedMap;
+        }
+        if (data instanceof Row) {
+            Row row = (Row) data;
+            Object[] encryptedFields = new Object[row.getArity()];
+            for (int i = 0; i < row.getArity(); i++) {
+                encryptedFields[i] = udf.eval(row.getField(i), keyId, algorithm);
+            }
+            return Row.of(encryptedFields);
+        }
+        throw new IllegalArgumentException("Unsupported data type for element-wise encryption: " + data.getClass());
+    }
+
+    @SuppressWarnings("unchecked")
+    Object decryptComplexFieldElementwise(DecryptUdf udf, Object encryptedData, Object originalType) {
+        // For complex types in ELEMENT mode, decrypt each element individually using the main UDF
+        if (encryptedData instanceof List && originalType instanceof List) {
+            List<String> encList = (List<String>) encryptedData;
+            List<?> origList = (List<?>) originalType;
+            List<Object> decryptedList = new ArrayList<>();
+            Object typeCapture = origList.isEmpty() ? "" : origList.get(0);
+            for (String encItem : encList) {
+                decryptedList.add(udf.eval(encItem, typeCapture));
+            }
+            return decryptedList;
+        }
+        if (encryptedData instanceof String[] && originalType instanceof String[]) {
+            String[] encArray = (String[]) encryptedData;
+            String[] decArray = new String[encArray.length];
+            for (int i = 0; i < encArray.length; i++) {
+                decArray[i] = udf.eval(encArray[i], "");
+            }
+            return decArray;
+        }
+        if (encryptedData instanceof Map && originalType instanceof Map) {
+            Map<?, String> encMap = (Map<?, String>) encryptedData;
+            Map<?, ?> origMap = (Map<?, ?>) originalType;
+            Map<Object, Object> decryptedMap = new LinkedHashMap<>();
+            Object typeCapture = origMap.isEmpty() ? 0 : origMap.values().iterator().next();
+            for (Map.Entry<?, String> entry : encMap.entrySet()) {
+                decryptedMap.put(entry.getKey(), udf.eval(entry.getValue(), typeCapture));
+            }
+            return decryptedMap;
+        }
+        if (encryptedData instanceof Row && originalType instanceof Row) {
+            Row encRow = (Row) encryptedData;
+            Row origRow = (Row) originalType;
+            Object[] decryptedFields = new Object[encRow.getArity()];
+            for (int i = 0; i < encRow.getArity(); i++) {
+                decryptedFields[i] = udf.eval((String) encRow.getField(i), origRow.getField(i));
+            }
+            return Row.of(decryptedFields);
+        }
+        throw new IllegalArgumentException("Unsupported data type combination for element-wise decryption");
+    }
+
+    void assertAllResultingFieldsMapRecord(Map<String, Object> expected, Map<String, Object> actual) {
+        assertAll(
+                expected.entrySet().stream().map(
+                        e -> e.getValue() instanceof byte[]
+                                ? () -> assertArrayEquals((byte[]) e.getValue(), (byte[]) actual.get(e.getKey()))
+                                : () -> assertEquals(e.getValue(), actual.get(e.getKey()))));
+    }
+
+    void assertAllResultingFieldsRowRecord(Row expected, Row actual) {
+        assertAll(
+                Stream.concat(
+                        Stream.<Executable>of(() -> assertEquals(expected.getArity(), actual.getArity())),
+                        Stream.iterate(0, i -> i < expected.getArity(), i -> i + 1).map(
+                                i -> {
+                                    if (expected.getField(i) instanceof byte[]) {
+                                        return () -> assertArrayEquals((byte[]) expected.getField(i),
+                                                (byte[]) actual.getField(i));
+                                    } else if (expected.getField(i) instanceof String[]) {
+                                        return () -> assertArrayEquals((String[]) expected.getField(i),
+                                                (String[]) actual.getField(i));
+                                    } else {
+                                        return () -> assertEquals(expected.getField(i), actual.getField(i));
+                                    }
+                                })));
+    }
+
+    private FunctionContext createMockFunctionContext(String cipherDataKeys, String cipherDataKeyIdentifier,
+            KryptoniteSettings.KeySource keySource, KryptoniteSettings.KmsType kmsType, String kmsConfig,
+            KryptoniteSettings.KekType kekType, String kekConfig, String kekUri) {
+
+        Configuration config = new Configuration();
+        config.setString(KryptoniteSettings.CIPHER_DATA_KEYS, cipherDataKeys);
+        config.setString(KryptoniteSettings.CIPHER_DATA_KEY_IDENTIFIER, cipherDataKeyIdentifier);
+        config.setString(KryptoniteSettings.KEY_SOURCE, keySource.name());
+        config.setString(KryptoniteSettings.KMS_TYPE, kmsType.name());
+        config.setString(KryptoniteSettings.KMS_CONFIG, kmsConfig);
+        config.setString(KryptoniteSettings.KEK_TYPE, kekType.name());
+        config.setString(KryptoniteSettings.KEK_CONFIG, kekConfig);
+        config.setString(KryptoniteSettings.KEK_URI, kekUri);
+
+        return new TestFunctionContext(config);
+    }
+
+    static class TestFunctionContext extends FunctionContext {
+        private final Configuration config;
+
+        public TestFunctionContext(Configuration config) {
+            super(null);
+            this.config = config;
+        }
+
+        public String getJobParameter(String key, String defaultValue) {
+            return config.getString(key, defaultValue);
+        }
+    }
+
+}

--- a/flink-udfs-kryptonite/src/test/java/com/github/hpgrahsl/flink/functions/kryptonite/TestFixtures.java
+++ b/flink-udfs-kryptonite/src/test/java/com/github/hpgrahsl/flink/functions/kryptonite/TestFixtures.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2025. Hans-Peter Grahsl (grahslhp@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.hpgrahsl.flink.functions.kryptonite;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.flink.types.Row;
+
+public class TestFixtures {
+
+    public static final String CIPHER_DATA_KEYS_EMPTY = "[]";
+
+    public static final String CIPHER_DATA_KEYS_CONFIG = "["
+            + "{\"identifier\":\"keyA\","
+            + "\"material\":{"
+            + "\"primaryKeyId\":1000000001,"
+            + "\"key\":["
+            + "{\"keyData\":"
+            + "{\"typeUrl\":\"type.googleapis.com/google.crypto.tink.AesGcmKey\","
+            + "\"value\":\"GhDRulECKAC8/19NMXDjeCjK\","
+            + "\"keyMaterialType\":\"SYMMETRIC\"},"
+            + "\"status\":\"ENABLED\","
+            + "\"keyId\":1000000001,"
+            + "\"outputPrefixType\":\"TINK\""
+            + "}"
+            + "]"
+            + "}"
+            + "},"
+            + "{\"identifier\":\"keyB\","
+            + "\"material\":{"
+            + "\"primaryKeyId\":1000000002,"
+            + "\"key\":["
+            + "{\"keyData\":"
+            + "{\"typeUrl\":\"type.googleapis.com/google.crypto.tink.AesGcmKey\","
+            + "\"value\":\"GiBIZWxsbyFXb3JsZEZVQ0sxYWJjZGprbCQxMjM0NTY3OA==\","
+            + "\"keyMaterialType\":\"SYMMETRIC\"},"
+            + "\"status\":\"ENABLED\","
+            + "\"keyId\":1000000002,"
+            + "\"outputPrefixType\":\"TINK\""
+            + "}"
+            + "]"
+            + "}"
+            + "},"
+            + "{\"identifier\":\"key9\","
+            + "\"material\":{"
+            + "\"primaryKeyId\":1000000003,"
+            + "\"key\":["
+            + "{\"keyData\":"
+            + "{\"typeUrl\":\"type.googleapis.com/google.crypto.tink.AesSivKey\","
+            + "\"value\":\"EkByiHi3H9shy2FO5UWgStNMmgqF629esenhnm0wZZArUkEU1/9l9J3ajJQI0GxDwzM1WFZK587W0xVB8KK4dqnz\","
+            + "\"keyMaterialType\":\"SYMMETRIC\"},"
+            + "\"status\":\"ENABLED\","
+            + "\"keyId\":1000000003,"
+            + "\"outputPrefixType\":\"TINK\""
+            + "}"
+            + "]"
+            + "}"
+            + "},"
+            + "{\"identifier\":\"key8\","
+            + "\"material\":{"
+            + "\"primaryKeyId\":1000000004,"
+            + "\"key\":["
+            + "{\"keyData\":"
+            + "{\"typeUrl\":\"type.googleapis.com/google.crypto.tink.AesSivKey\","
+            + "\"value\":\"EkBWT3ZL7DmAN91erW3xAzMFDWMaQx34Su3VlaMiTWzjVDbKsH3IRr2HQFnaMvvVz2RH/+eYXn3zvAzWJbReCto/\","
+            + "\"keyMaterialType\":\"SYMMETRIC\"},"
+            + "\"status\":\"ENABLED\","
+            + "\"keyId\":1000000004,"
+            + "\"outputPrefixType\":\"TINK\""
+            + "}"
+            + "]"
+            + "}"
+            + "}"
+            + "]";
+
+    public static final String CIPHER_DATA_KEYS_CONFIG_ENCRYPTED = "["
+            + "    {"
+            + "        \"identifier\": \"keyX\","
+            + "        \"material\": {"
+            + "            \"encryptedKeyset\": \"CiQAxVFVnXQGci+bKTFoJwYENusDTbOmB+akfwJH3V9yRJXu8HwShQEAjEQQ+iL+3/Y8/Q7PcTgSJTAr8yUkNbFf7715soTCa9pfxFLxv78aZOwONmIktL1ntM8+uQfOt7Ka3nYxrrzitJORFSh8pIQBE7B1vcbhCJQk5+8mSnNcYcAgk90Es8qAiVeptfVaw0VLWok4/ejnsogaD0gLEOeR/4FJfKELj7LLUgLf\","
+            + "            \"keysetInfo\": {"
+            + "                \"primaryKeyId\": 1070658096,"
+            + "                \"keyInfo\": ["
+            + "                    {"
+            + "                        \"typeUrl\": \"type.googleapis.com/google.crypto.tink.AesGcmKey\","
+            + "                        \"status\": \"ENABLED\","
+            + "                        \"keyId\": 1070658096,"
+            + "                        \"outputPrefixType\": \"TINK\""
+            + "                    }"
+            + "                ]"
+            + "            }"
+            + "        }"
+            + "    },"
+            + "    {"
+            + "        \"identifier\": \"keyY\","
+            + "        \"material\": {"
+            + "            \"encryptedKeyset\": \"CiQAxVFVnYb69VZimvSnRRsxEhFMbHHTW4BaGHVMLKTZrXViaPwSlAEAjEQQ+iDiddqY3C/jHIjAsU5Ph+gQULl4Xi6mmKusbjTiBzQkIwuXg+nE3Y1C0GFSl7LEqtBQuyb7L0w5CsjGRBoRLhyqJUfil92AAb1yC7j+ArxvcV+T970KPyVG9QdDcJ2fiYqNqwLf8dwqPP0n+nAHksF0DpQf6yg3vslox0GIVxauojPdbq9pFuQUTZyGVs/a\","
+            + "            \"keysetInfo\": {"
+            + "                \"primaryKeyId\": 1053599701,"
+            + "                \"keyInfo\": ["
+            + "                    {"
+            + "                        \"typeUrl\": \"type.googleapis.com/google.crypto.tink.AesGcmKey\","
+            + "                        \"status\": \"ENABLED\","
+            + "                        \"keyId\": 1053599701,"
+            + "                        \"outputPrefixType\": \"TINK\""
+            + "                    }"
+            + "                ]"
+            + "            }"
+            + "        }"
+            + "    },"
+            + "    {"
+            + "        \"identifier\": \"key1\","
+            + "        \"material\": {"
+            + "            \"encryptedKeyset\": \"CiQAxVFVnfzb8jhDAfGwquh5lxU0R+blpz7DP/00cF8aq4gLtuIStwEAjEQQ+vGbPfFxa07XkaMHEP7TU9PGsd0l38St3CckCrgVnzYidrX3H4XtN58VUFN5eTXcIq3Rx2gsx/RaSpe85o+MP33woGM9Va4s/INyjeeCQVsJnoWU1EqLchfU8BnL0dAXwajj3Bj5X3oL8k22TNome2ywDKjrXz4AU75QYNwta000SmRxlY7UbmR1Mv38Nrs2qvy5P8B6fOYPusamtFJkJWG/dxJpoS+4URWcCc2yfrCY4yg=\","
+            + "            \"keysetInfo\": {"
+            + "                \"primaryKeyId\": 1932849140,"
+            + "                \"keyInfo\": ["
+            + "                    {"
+            + "                        \"typeUrl\": \"type.googleapis.com/google.crypto.tink.AesSivKey\","
+            + "                        \"status\": \"ENABLED\","
+            + "                        \"keyId\": 1932849140,"
+            + "                        \"outputPrefixType\": \"TINK\""
+            + "                    }"
+            + "                ]"
+            + "            }"
+            + "        }"
+            + "    },"
+            + "    {"
+            + "        \"identifier\": \"key0\","
+            + "        \"material\": {"
+            + "            \"encryptedKeyset\": \"CiQAxVFVnUUw/pZSdQXtve5M+wgVBlGqPJwuf4X9SmWB4B1u4OQStQEAjEQQ+iXK6u/gbul2QpS0mIO2wqUwiOBHz5C+MZ2JKyjKlzMA8yGlyqoN54qhRJA5IazFUIJVWNigXBDUU0km1Bm1oFDdzb6pMVZY5HDH26AiyJZOQSjglLAz+SoYR3DjHapkWNDv2QGacP/5qCwC7zOCc89pZxEDtT+eJvVsJqUHV6VGJYnIVYQBwxBAzy3XsPWm6IARj5VHtLwOTuM3UNP96Bwk/jzR6Ot+izXASRTeHomP\","
+            + "            \"keysetInfo\": {"
+            + "                \"primaryKeyId\": 151824924,"
+            + "                \"keyInfo\": ["
+            + "                    {"
+            + "                        \"typeUrl\": \"type.googleapis.com/google.crypto.tink.AesSivKey\","
+            + "                        \"status\": \"ENABLED\","
+            + "                        \"keyId\": 151824924,"
+            + "                        \"outputPrefixType\": \"TINK\""
+            + "                    }"
+            + "                ]"
+            + "            }"
+            + "        }"
+            + "    }"
+            + "]";
+
+    static Map<String, Object> TEST_OBJ_MAP_1;
+    static Row TEST_OBJ_ROW_1;
+
+    static {
+        TEST_OBJ_MAP_1 = new LinkedHashMap<>();
+        TEST_OBJ_MAP_1.put("id", "1234567890");
+        TEST_OBJ_MAP_1.put("myString", "keyB");
+        TEST_OBJ_MAP_1.put("myInt", 42);
+        TEST_OBJ_MAP_1.put("myBoolean", true);
+        TEST_OBJ_MAP_1.put("mySubDoc1", Map.of("myString", "keyA"));
+        TEST_OBJ_MAP_1.put("myArray1", List.of("str_1", "str_2", "...", "str_N"));
+        TEST_OBJ_MAP_1.put("mySubDoc2", Map.of("k1", 9, "k2", 8, "k3", 7));
+        TEST_OBJ_MAP_1.put("myBytes", "S2Fma2Egcm9ja3Mh");
+
+        TEST_OBJ_ROW_1 = Row.of(
+                "1234567890",
+                "some foo bla text",
+                42,
+                true,
+                Row.of("hello json"),
+                new String[]{"str_1", "str_2", "...", "str_N"},
+                Map.of("k1", 9, "k2", 8, "k3", 7),
+                new byte[] { 75, 97, 102, 107, 97, 32, 114, 111, 99, 107, 115, 33 });
+    }
+
+}

--- a/flink-udfs-kryptonite/src/test/java/com/github/hpgrahsl/flink/functions/kryptonite/TestFixturesCloudKms.java
+++ b/flink-udfs-kryptonite/src/test/java/com/github/hpgrahsl/flink/functions/kryptonite/TestFixturesCloudKms.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025. Hans-Peter Grahsl (grahslhp@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.hpgrahsl.flink.functions.kryptonite;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+public class TestFixturesCloudKms {
+
+    private static final String PATH = "src/test/resources/credentials.properties";
+    private static final Properties CREDENTIALS = new Properties();
+
+    public static synchronized Properties readCredentials() throws IOException {
+        if(!CREDENTIALS.isEmpty()) {
+            return CREDENTIALS;
+        }
+        try (InputStreamReader isr = new FileReader(new File(PATH), StandardCharsets.UTF_8)) {
+            CREDENTIALS.load(isr);
+            return CREDENTIALS;
+        }
+    }
+
+}


### PR DESCRIPTION
Implement test coverage for flink-udfs-kryptonite module following the same structure and approach as existing ksqlDB UDF tests.

Test coverage includes:
- Encryption/decryption round-trip tests for Row and Map data structures
- Support for both ELEMENT and OBJECT encryption modes
- Tests for AES-GCM and AES-GCM-SIV cipher algorithms
- Cloud KMS integration tests (skipped without credentials)

New test files:
- CipherFieldEncryptDecryptUdfFunctionalTest.java: Main test class
- TestFixtures.java: Test data and cipher key configurations
- TestFixturesCloudKms.java: Cloud KMS credential loader

Also adds CLAUDE.md with project overview, build commands, and architecture documentation for future Claude Code sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)