### PR TITLE
☑️ explicitly allow NONE for KeySource 🗝️

### DIFF
--- a/connect-transform-kryptonite/src/main/java/com/github/hpgrahsl/kafka/connect/transforms/kryptonite/CipherField.java
+++ b/connect-transform-kryptonite/src/main/java/com/github/hpgrahsl/kafka/connect/transforms/kryptonite/CipherField.java
@@ -87,7 +87,7 @@ public abstract class CipherField<R extends ConnectRecord<R>> implements Transfo
       .define(CIPHER_MODE, Type.STRING, ConfigDef.NO_DEFAULT_VALUE, new CipherModeValidator(),
           ConfigDef.Importance.HIGH, "defines whether the data should get encrypted or decrypted")
       .define(KEY_SOURCE, Type.STRING, KEY_SOURCE_DEFAULT, new KeySourceValidator(), ConfigDef.Importance.HIGH,
-          "defines the origin of the Tink keysets which can be defined directly in the config or fetched from a remote/cloud KMS (see <pre>kms_type</pre> and <pre>kms_config</pre>)")
+          "defines the origin of the Tink keysets (CONFIG, CONFIG_ENCRYPTED, KMS, KMS_ENCRYPTED) or NONE to skip keyset-based encryption entirely and rely solely on envelope encryption via <pre>envelope_kek_configs</pre>")
       .define(KMS_TYPE, Type.STRING, KMS_TYPE_DEFAULT, new KmsTypeValidator(),
           ConfigDef.Importance.MEDIUM, "defines from which remote/cloud KMS keysets are resolved from")
       .define(KMS_CONFIG, Type.PASSWORD, KMS_CONFIG_DEFAULT, ConfigDef.Importance.MEDIUM,

--- a/funqy-http-kryptonite/src/main/java/com/github/hpgrahsl/funqy/http/kryptonite/KryptoniteConfiguration.java
+++ b/funqy-http-kryptonite/src/main/java/com/github/hpgrahsl/funqy/http/kryptonite/KryptoniteConfiguration.java
@@ -38,7 +38,7 @@ public class KryptoniteConfiguration {
         OBJECT
     }
     
-    @ConfigProperty(name="cipher_data_keys")
+    @ConfigProperty(name="cipher_data_keys", defaultValue = "[]")
     public String cipherDataKeys;
 
     @ConfigProperty(name="cipher_data_key_identifier")

--- a/kroxylicious-filter-kryptonite/src/main/java/com/github/hpgrahsl/kroxylicious/filters/kryptonite/config/KryptoniteFilterConfig.java
+++ b/kroxylicious-filter-kryptonite/src/main/java/com/github/hpgrahsl/kroxylicious/filters/kryptonite/config/KryptoniteFilterConfig.java
@@ -20,7 +20,7 @@ import java.util.Map;
 public class KryptoniteFilterConfig {
 
     // --- Key management ---
-    private final String keySource;                 // CONFIG | CONFIG_ENCRYPTED | KMS | KMS_ENCRYPTED
+    private final String keySource;                 // CONFIG | CONFIG_ENCRYPTED | KMS | KMS_ENCRYPTED | NONE
     private final String cipherAlgorithm;           // default: "TINK/AES_GCM"
     private final String cipherDataKeyIdentifier;   // default key id used when a field has no per-field keyId
     private final List<Map<String, Object>> cipherDataKeys;
@@ -159,7 +159,7 @@ public class KryptoniteFilterConfig {
         try {
             parsedKeySource = KeySource.valueOf(keySource);
         } catch (IllegalArgumentException | NullPointerException e) {
-            errors.add("key_source is invalid: '" + keySource + "' — must be one of CONFIG, CONFIG_ENCRYPTED, KMS, KMS_ENCRYPTED");
+            errors.add("key_source is invalid: '" + keySource + "' — must be one of CONFIG, CONFIG_ENCRYPTED, KMS, KMS_ENCRYPTED, NONE");
         }
 
         if (parsedKeySource != null) {

--- a/kryptonite/src/main/java/com/github/hpgrahsl/kryptonite/Kryptonite.java
+++ b/kryptonite/src/main/java/com/github/hpgrahsl/kryptonite/Kryptonite.java
@@ -474,6 +474,8 @@ public class Kryptonite implements AutoCloseable {
       var keySource = KeySource.valueOf(config.get(KEY_SOURCE));
       LOG.log(INFO, "creating Kryptonite instance from config (keySource={0})", keySource);
       switch (keySource) {
+        case NONE:
+          return withoutKeyVault(config);
         case CONFIG:
           return withTinkKeyVault(config);
         case CONFIG_ENCRYPTED:
@@ -490,6 +492,21 @@ public class Kryptonite implements AutoCloseable {
     } catch (Exception e) {
       throw new ConfigurationException(e.getMessage(), e);
     }
+  }
+
+  private static Kryptonite withoutKeyVault(Map<String,String> config) {
+    LOG.log(INFO, "key vault: none -> envelope encryption only");
+    var sessionCache = encryptDekSessionCache(config);
+    var dekSizeBytes = dekSizeBytes(config);
+    var edekStore = buildEdekStore(config);
+    var registry = buildEnvelopeKekRegistry(config, sessionCache, dekSizeBytes, edekStore);
+    if (registry == null) {
+      throw new ConfigurationException(
+          "key_source=NONE requires envelope encryption to be configured — "
+              + "envelope_kek_configs must be a non-empty list of KEK entries");
+    }
+    validateEnvelopeKmsConfig(registry, edekStore);
+    return new Kryptonite(new TinkKeyVault(Map.of()), wrappedDekCache(config), sessionCache, registry, edekStore, dekSizeBytes);
   }
 
   private static Kryptonite withTinkKeyVault(Map<String,String> config)

--- a/kryptonite/src/main/java/com/github/hpgrahsl/kryptonite/config/KryptoniteSettings.java
+++ b/kryptonite/src/main/java/com/github/hpgrahsl/kryptonite/config/KryptoniteSettings.java
@@ -6,7 +6,8 @@ public class KryptoniteSettings {
     CONFIG,
     KMS,
     CONFIG_ENCRYPTED,
-    KMS_ENCRYPTED
+    KMS_ENCRYPTED,
+    NONE
   }
 
   public enum KmsType {


### PR DESCRIPTION
This is the right choice for anyone doing envelope encryption
exclusively as it means there are no tink keysets involved at all.