### PR TITLE
🔐 dynamic key identifiers 🔎

### DIFF
--- a/connect-transform-kryptonite/src/main/java/com/github/hpgrahsl/kafka/connect/transforms/kryptonite/CipherField.java
+++ b/connect-transform-kryptonite/src/main/java/com/github/hpgrahsl/kafka/connect/transforms/kryptonite/CipherField.java
@@ -72,6 +72,8 @@ public abstract class CipherField<R extends ConnectRecord<R>> implements Transfo
           "defines how to process complex field types (maps, lists, structs), either as full objects or element-wise")
       .define(CIPHER_ALGORITHM, Type.STRING, CIPHER_ALGORITHM_DEFAULT, new CipherNameValidator(),
           ConfigDef.Importance.LOW, "cipher algorithm used for data encryption (currently supports only one AEAD cipher: "+CIPHER_ALGORITHM_DEFAULT+")")
+      .define(DYNAMIC_KEY_ID_PREFIX, Type.STRING, DYNAMIC_KEY_ID_PREFIX_DEFAULT,
+          ConfigDef.Importance.LOW, "prefix that marks key identifiers as dynamic so the remaining suffix is resolved as a field path against the current record")
       .define(CIPHER_DATA_KEYS, Type.PASSWORD, CIPHER_DATA_KEYS_DEFAULT,
           ConfigDef.Importance.HIGH, "JSON array with data key objects specifying the key identifiers together with key sets for encryption / decryption which are defined in Tink's key specification format")
       .define(CIPHER_DATA_KEY_IDENTIFIER, Type.STRING, CIPHER_DATA_KEY_IDENTIFIER_DEFAULT,
@@ -197,6 +199,7 @@ public abstract class CipherField<R extends ConnectRecord<R>> implements Transfo
       Map.entry(PATH_DELIMITER, Optional.ofNullable(config.getString(PATH_DELIMITER)).orElse(PATH_DELIMITER_DEFAULT)),
       Map.entry(FIELD_MODE, Optional.ofNullable(config.getString(FIELD_MODE)).orElse(FIELD_MODE_DEFAULT)),
       Map.entry(CIPHER_ALGORITHM, Optional.ofNullable(config.getString(CIPHER_ALGORITHM)).orElse(CIPHER_ALGORITHM_DEFAULT)),
+      Map.entry(DYNAMIC_KEY_ID_PREFIX, Optional.ofNullable(config.getString(DYNAMIC_KEY_ID_PREFIX)).orElse(DYNAMIC_KEY_ID_PREFIX_DEFAULT)),
       Map.entry(CIPHER_DATA_KEYS, Optional.ofNullable(config.getPassword(CIPHER_DATA_KEYS).value()).orElse(CIPHER_DATA_KEYS_DEFAULT)),
       Map.entry(CIPHER_DATA_KEY_IDENTIFIER, Optional.ofNullable(config.getString(CIPHER_DATA_KEY_IDENTIFIER)).orElse(CIPHER_DATA_KEY_IDENTIFIER_DEFAULT)),
       Map.entry(CIPHER_TEXT_ENCODING, Optional.ofNullable(config.getString(CIPHER_TEXT_ENCODING)).orElse(CIPHER_TEXT_ENCODING_DEFAULT)),

--- a/connect-transform-kryptonite/src/main/java/com/github/hpgrahsl/kafka/connect/transforms/kryptonite/DynamicKeyIdResolver.java
+++ b/connect-transform-kryptonite/src/main/java/com/github/hpgrahsl/kafka/connect/transforms/kryptonite/DynamicKeyIdResolver.java
@@ -1,0 +1,153 @@
+package com.github.hpgrahsl.kafka.connect.transforms.kryptonite;
+
+import com.github.hpgrahsl.kryptonite.Kryptonite;
+import com.github.hpgrahsl.kryptonite.config.KryptoniteSettings;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+
+import java.util.Arrays;
+import java.util.Map;
+
+/**
+ * Resolves dynamic key identifiers for the Kafka Connect SMT against the root record.
+ *
+ * <p>The SMT supports both schemaless records represented as {@code Map<String, Object>}
+ * and schema-aware records represented as {@link Struct}. This helper provides overloaded
+ * entry points for both shapes and applies the same resolution rules in each case.
+ *
+ * <p>The effective configured identifier is selected as follows:
+ * <ul>
+ *   <li>use the field-level {@code keyId} if present</li>
+ *   <li>otherwise, if the effective algorithm is {@code TINK/AES_GCM_ENVELOPE_KMS},
+ *       fall back to {@code envelope_kek_identifier}</li>
+ *   <li>otherwise fall back to {@code cipher_data_key_identifier}</li>
+ * </ul>
+ *
+ * <p>If the selected identifier starts with {@code dynamic_key_id_prefix}, the remaining
+ * suffix is interpreted as a field path and resolved from the root record. The extracted
+ * value must be a non-blank {@link String}; otherwise resolution fails with a
+ * {@link DataException}.
+ */
+final class DynamicKeyIdResolver {
+
+    private DynamicKeyIdResolver() {
+    }
+
+    static String resolve(FieldConfig fieldConfig, AbstractConfig config, Map<String, Object> rootRecord) {
+        var configuredKeyId = configuredKeyId(fieldConfig, config);
+        var prefix = config.getString(KryptoniteSettings.DYNAMIC_KEY_ID_PREFIX);
+        if (!configuredKeyId.startsWith(prefix)) {
+            return configuredKeyId;
+        }
+        var fieldPath = stripPrefix(configuredKeyId, prefix);
+        return requireNonBlank(extractFromMap(rootRecord, fieldPath, config.getString(KryptoniteSettings.PATH_DELIMITER)), configuredKeyId, fieldPath);
+    }
+
+    static String resolve(FieldConfig fieldConfig, AbstractConfig config, Struct rootRecord) {
+        var configuredKeyId = configuredKeyId(fieldConfig, config);
+        var prefix = config.getString(KryptoniteSettings.DYNAMIC_KEY_ID_PREFIX);
+        if (!configuredKeyId.startsWith(prefix)) {
+            return configuredKeyId;
+        }
+        var fieldPath = stripPrefix(configuredKeyId, prefix);
+        return requireNonBlank(extractFromStruct(rootRecord, fieldPath, config.getString(KryptoniteSettings.PATH_DELIMITER)), configuredKeyId, fieldPath);
+    }
+
+    private static String configuredKeyId(FieldConfig fieldConfig, AbstractConfig config) {
+        return fieldConfig.getKeyId().orElseGet(() -> defaultConfiguredKeyId(fieldConfig, config));
+    }
+
+    private static String defaultConfiguredKeyId(FieldConfig fieldConfig, AbstractConfig config) {
+        var algorithm = fieldConfig.getAlgorithm().orElseGet(() -> config.getString(KryptoniteSettings.CIPHER_ALGORITHM));
+        var cipherSpec = Kryptonite.CipherSpec.fromName(algorithm.toUpperCase());
+        return cipherSpec instanceof Kryptonite.KmsEnvelopeCipherSpec
+                ? config.getString(KryptoniteSettings.ENVELOPE_KEK_IDENTIFIER)
+                : config.getString(KryptoniteSettings.CIPHER_DATA_KEY_IDENTIFIER);
+    }
+
+    private static String stripPrefix(String configuredKeyId, String prefix) {
+        var fieldPath = configuredKeyId.substring(prefix.length());
+        if (fieldPath.isBlank()) {
+            throw new DataException("Dynamic key identifier '" + configuredKeyId + "' has no field path after prefix '" + prefix + "'");
+        }
+        return fieldPath;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static String extractFromMap(Map<String, Object> rootRecord, String fieldPath, String pathDelimiter) {
+        if (!fieldPath.contains(pathDelimiter)) {
+            var value = rootRecord.get(fieldPath);
+            return requireString(value, fieldPath, false);
+        }
+        var fields = fieldPath.split("\\" + pathDelimiter);
+        var head = rootRecord.get(fields[0]);
+        if (head instanceof Map<?, ?> mapValue) {
+            return extractFromMap((Map<String, Object>) mapValue,
+                    String.join(pathDelimiter, Arrays.copyOfRange(fields, 1, fields.length)), pathDelimiter);
+        }
+        if (head instanceof Struct structValue) {
+            return extractFromStruct(structValue,
+                    String.join(pathDelimiter, Arrays.copyOfRange(fields, 1, fields.length)), pathDelimiter);
+        }
+        throw missingOrWrongIntermediate(fieldPath);
+    }
+
+    private static String extractFromStruct(Struct rootRecord, String fieldPath, String pathDelimiter) {
+        if (!fieldPath.contains(pathDelimiter)) {
+            if (rootRecord.schema().field(fieldPath) == null) {
+                throw missingOrWrongValue(fieldPath, false);
+            }
+            var value = rootRecord.get(fieldPath);
+            return requireString(value, fieldPath, false);
+        }
+        var fields = fieldPath.split("\\" + pathDelimiter);
+        if (rootRecord.schema().field(fields[0]) == null) {
+            throw missingOrWrongIntermediate(fieldPath);
+        }
+        var head = rootRecord.get(fields[0]);
+        if (head instanceof Struct structValue) {
+            return extractFromStruct(structValue,
+                    String.join(pathDelimiter, Arrays.copyOfRange(fields, 1, fields.length)), pathDelimiter);
+        }
+        if (head instanceof Map<?, ?> mapValue) {
+            @SuppressWarnings("unchecked")
+            var typedMap = (Map<String, Object>) mapValue;
+            return extractFromMap(typedMap,
+                    String.join(pathDelimiter, Arrays.copyOfRange(fields, 1, fields.length)), pathDelimiter);
+        }
+        throw missingOrWrongIntermediate(fieldPath);
+    }
+
+    private static String requireString(Object value, String fieldPath, boolean intermediate) {
+        if (value == null) {
+            throw missingOrWrongValue(fieldPath, intermediate);
+        }
+        if (!(value instanceof String stringValue)) {
+            throw new DataException("Dynamic key identifier resolution failed for field path '" + fieldPath
+                    + "': resolved to type " + value.getClass().getSimpleName() + " but a string value is required");
+        }
+        return stringValue;
+    }
+
+    private static String requireNonBlank(String extracted, String configuredKeyId, String fieldPath) {
+        if (extracted.isBlank()) {
+            throw new DataException("Dynamic key identifier resolution failed for expression '" + configuredKeyId
+                    + "': field path '" + fieldPath + "' resolved to a blank string but a non-blank key id is required");
+        }
+        return extracted;
+    }
+
+    private static DataException missingOrWrongIntermediate(String fieldPath) {
+        return new DataException("Dynamic key identifier resolution failed for field path '" + fieldPath
+                + "': an intermediate path segment was missing or did not resolve to a structured object");
+    }
+
+    private static DataException missingOrWrongValue(String fieldPath, boolean intermediate) {
+        if (intermediate) {
+            return missingOrWrongIntermediate(fieldPath);
+        }
+        return new DataException("Dynamic key identifier resolution failed for field path '" + fieldPath
+                + "': field was not found or resolved to null");
+    }
+}

--- a/connect-transform-kryptonite/src/main/java/com/github/hpgrahsl/kafka/connect/transforms/kryptonite/RecordHandler.java
+++ b/connect-transform-kryptonite/src/main/java/com/github/hpgrahsl/kafka/connect/transforms/kryptonite/RecordHandler.java
@@ -23,6 +23,7 @@ import com.github.hpgrahsl.kryptonite.config.KryptoniteSettings.AlphabetTypeFPE;
 import com.github.hpgrahsl.kryptonite.serdes.FieldHandler;
 
 import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,28 +70,32 @@ class RecordHandler {
     return CipherSpec.fromName(fieldMetaData.getAlgorithm().toUpperCase()).isCipherFPE();
   }
 
-  FieldMetaData determineFieldMetaData(Object object, String fieldPath) {
-    return Optional.ofNullable(fieldConfig.get(fieldPath))
-        .or(() -> resolveElementModeParentPath(fieldPath).map(fieldConfig::get))
-        .map(fc ->
-            FieldMetaData.builder()
-                .algorithm(fc.getAlgorithm().orElseGet(() -> config.getString(KryptoniteSettings.CIPHER_ALGORITHM)))
-                .dataType(Optional.ofNullable(object).map(o -> o.getClass().getName()).orElse(""))
-                .keyId(fc.getKeyId().orElseGet(() -> config.getString(KryptoniteSettings.CIPHER_DATA_KEY_IDENTIFIER)))
-                .fpeTweak(fc.getFpeTweak().orElseGet(() -> config.getString(KryptoniteSettings.CIPHER_FPE_TWEAK)))
-                .fpeAlphabet(determineAlphabetFromFieldConfig(fc))
-                .encoding(fc.getEncoding().orElse(config.getString(KryptoniteSettings.CIPHER_TEXT_ENCODING)))
-                .build()
-        ).orElseGet(
-            () -> FieldMetaData.builder()
-                .algorithm(config.getString(KryptoniteSettings.CIPHER_ALGORITHM))
-                .dataType(Optional.ofNullable(object).map(o -> o.getClass().getName()).orElse(""))
-                .keyId(config.getString(KryptoniteSettings.CIPHER_DATA_KEY_IDENTIFIER))
-                .fpeTweak(config.getString(KryptoniteSettings.CIPHER_FPE_TWEAK))
-                .fpeAlphabet(getAlphabetFromGlobalConfig())
-                .encoding(config.getString(KryptoniteSettings.CIPHER_TEXT_ENCODING))
-                .build()
-        );
+  FieldMetaData determineFieldMetaData(Object rootRecord, Object fieldValue, String fieldPath) {
+    var fieldConfig = Optional.ofNullable(this.fieldConfig.get(fieldPath))
+        .or(() -> resolveElementModeParentPath(fieldPath).map(this.fieldConfig::get))
+        .orElseGet(() -> FieldConfig.builder().name(fieldPath).build());
+    var algorithm = fieldConfig.getAlgorithm().orElseGet(() -> config.getString(KryptoniteSettings.CIPHER_ALGORITHM));
+    var keyId = resolveKeyId(fieldConfig, rootRecord);
+    return FieldMetaData.builder()
+        .algorithm(algorithm)
+        .dataType(Optional.ofNullable(fieldValue).map(o -> o.getClass().getName()).orElse(""))
+        .keyId(keyId)
+        .fpeTweak(fieldConfig.getFpeTweak().orElseGet(() -> config.getString(KryptoniteSettings.CIPHER_FPE_TWEAK)))
+        .fpeAlphabet(determineAlphabetFromFieldConfig(fieldConfig))
+        .encoding(fieldConfig.getEncoding().orElse(config.getString(KryptoniteSettings.CIPHER_TEXT_ENCODING)))
+        .build();
+  }
+
+  private String resolveKeyId(FieldConfig fieldConfig, Object rootRecord) {
+    if (rootRecord instanceof Map<?, ?> rootMap) {
+      @SuppressWarnings("unchecked")
+      var typedMap = (Map<String, Object>) rootMap;
+      return DynamicKeyIdResolver.resolve(fieldConfig, config, typedMap);
+    }
+    if (rootRecord instanceof Struct rootStruct) {
+      return DynamicKeyIdResolver.resolve(fieldConfig, config, rootStruct);
+    }
+    return fieldConfig.getKeyId().orElseGet(() -> config.getString(KryptoniteSettings.CIPHER_DATA_KEY_IDENTIFIER));
   }
 
   /**
@@ -108,24 +113,24 @@ class RecordHandler {
     return mode == CipherField.FieldMode.ELEMENT ? Optional.of(parentPath) : Optional.empty();
   }
 
-  String encryptNonFPE(Object object, FieldMetaData fieldMetaData) {
-    LOGGER.trace("object to be encrypted: {}", object);
+  String encryptNonFPE(Object fieldValue, FieldMetaData fieldMetaData) {
+    LOGGER.trace("object to be encrypted: {}", fieldValue);
     var metadata = PayloadMetaData.from(fieldMetaData);
-    var encodedField = FieldHandler.encryptField(object, metadata, kryptonite, config.getString(KryptoniteSettings.SERDE_TYPE));
+    var encodedField = FieldHandler.encryptField(fieldValue, metadata, kryptonite, config.getString(KryptoniteSettings.SERDE_TYPE));
     LOGGER.trace("returning encoded field: {}", encodedField);
     return encodedField;
   }
 
-  String encryptFPE(Object object, FieldMetaData fieldMetaData) {
-    LOGGER.trace("object to be FPE encrypted: {}", object);
-    if (object == null) {
+  String encryptFPE(Object fieldValue, FieldMetaData fieldMetaData) {
+    LOGGER.trace("object to be FPE encrypted: {}", fieldValue);
+    if (fieldValue == null) {
       return null;
     }
-    if (!(object instanceof String)) {
+    if (!(fieldValue instanceof String)) {
       throw new DataException("FPE encryption only supported for String data types but found: "
-          + object.getClass().getName());
+          + fieldValue.getClass().getName());
     }
-    var plaintext = ((String) object).getBytes(StandardCharsets.UTF_8);
+    var plaintext = ((String) fieldValue).getBytes(StandardCharsets.UTF_8);
     var ciphertext = new String(kryptonite.cipherFieldFPE(plaintext, fieldMetaData), StandardCharsets.UTF_8);
     LOGGER.debug("FPE encrypted field: {}", ciphertext);
     return ciphertext;
@@ -135,26 +140,26 @@ class RecordHandler {
    * Decrypts the encoded field and returns the raw serde output.
    * The caller is responsible for any post-decrypt type conversion.
    */
-  Object decryptNonFPE(Object object) {
-    if (object == null) {
+  Object decryptNonFPE(Object fieldValue) {
+    if (fieldValue == null) {
       return null;
     }
-    LOGGER.debug("object to be decrypted: {}", object);
-    var restoredField = FieldHandler.decryptField((String) object, kryptonite);
+    LOGGER.debug("object to be decrypted: {}", fieldValue);
+    var restoredField = FieldHandler.decryptField((String) fieldValue, kryptonite);
     LOGGER.trace("restored field: {}", restoredField);
     return restoredField;
   }
 
-  String decryptFPE(Object object, FieldMetaData fieldMetaData) {
-    if (object == null) {
+  String decryptFPE(Object fieldValue, FieldMetaData fieldMetaData) {
+    if (fieldValue == null) {
       return null;
     }
-    if (!(object instanceof String)) {
+    if (!(fieldValue instanceof String)) {
       throw new DataException("FPE decryption only supported for String data types but found: "
-          + object.getClass().getName());
+          + fieldValue.getClass().getName());
     }
-    LOGGER.debug("object to be FPE decrypted: {}", object);
-    var ciphertext = ((String) object).getBytes(StandardCharsets.UTF_8);
+    LOGGER.debug("object to be FPE decrypted: {}", fieldValue);
+    var ciphertext = ((String) fieldValue).getBytes(StandardCharsets.UTF_8);
     var plaintext = new String(kryptonite.decipherFieldFPE(ciphertext, fieldMetaData), StandardCharsets.UTF_8);
     LOGGER.trace("FPE decrypted field: {}", plaintext);
     return plaintext;

--- a/connect-transform-kryptonite/src/main/java/com/github/hpgrahsl/kafka/connect/transforms/kryptonite/SchemaawareRecordHandler.java
+++ b/connect-transform-kryptonite/src/main/java/com/github/hpgrahsl/kafka/connect/transforms/kryptonite/SchemaawareRecordHandler.java
@@ -52,66 +52,78 @@ public class SchemaawareRecordHandler implements FieldPathMatcher {
   }
 
   @Override
-  public Object matchFields(Schema schemaOriginal, Object objectOriginal, Schema schemaNew,
-      Object objectNew, String matchedPath) {
-    LOGGER.trace("checking fields in record {}", objectOriginal);
-    var dataOriginal = (Struct) objectOriginal;
-    var dataNew = (Struct) objectNew;
-    schemaOriginal.fields().forEach(f -> {
-      var updatedPath = matchedPath.isEmpty() ? f.name() : matchedPath + handler.pathDelimiter + f.name();
+  public Object matchFields(Schema sourceSchema, Object sourceRecord, Schema targetSchema,
+      Object targetRecord, String matchedPath) {
+    return matchFields((Struct) sourceRecord, sourceSchema, (Struct) sourceRecord,
+        targetSchema, (Struct) targetRecord, matchedPath);
+  }
+
+  /**
+   * Recursively traverses the current source/target struct pair while keeping the original
+   * top-level record available for aspects such as dynamic key id resolution.
+   */
+  private Object matchFields(Struct rootRecord, Schema sourceSchema, Struct sourceStruct, Schema targetSchema,
+      Struct targetStruct, String matchedPath) {
+    LOGGER.trace("checking fields in record {}", sourceStruct);
+    sourceSchema.fields().forEach(field -> {
+      var updatedPath = matchedPath.isEmpty() ? field.name() : matchedPath + handler.pathDelimiter + field.name();
       var fc = handler.fieldConfig.get(updatedPath);
       if (fc != null) {
         LOGGER.trace("matched field '{}'", updatedPath);
         if (FieldMode.ELEMENT == fc.getFieldMode()
             .orElse(FieldMode.valueOf(handler.getConfig().getString(KryptoniteSettings.FIELD_MODE)))) {
-          if (f.schema().type() == Type.ARRAY) {
+          if (field.schema().type() == Type.ARRAY) {
             LOGGER.trace("processing {} field element-wise", Type.ARRAY);
-            dataNew.put(schemaNew.field(f.name()), processListField((List<?>) dataOriginal.get(f.name()), updatedPath, f.schema().valueSchema()));
-          } else if (f.schema().type() == Type.MAP) {
+            targetStruct.put(targetSchema.field(field.name()), processListField(rootRecord,
+                (List<?>) sourceStruct.get(field.name()), updatedPath, field.schema().valueSchema()));
+          } else if (field.schema().type() == Type.MAP) {
             LOGGER.trace("processing {} field element-wise", Type.MAP);
-            dataNew.put(schemaNew.field(f.name()), processMapField((Map<?, ?>) dataOriginal.get(f.name()), updatedPath, f.schema().valueSchema()));
-          } else if (f.schema().type() == Type.STRUCT) {
-            if (dataOriginal.get(f.name()) != null) {
+            targetStruct.put(targetSchema.field(field.name()), processMapField(rootRecord,
+                (Map<?, ?>) sourceStruct.get(field.name()), updatedPath, field.schema().valueSchema()));
+          } else if (field.schema().type() == Type.STRUCT) {
+            if (sourceStruct.get(field.name()) != null) {
               LOGGER.trace("processing {} field element-wise", Type.STRUCT);
-              dataNew.put(schemaNew.field(f.name()),
-                  matchFields(f.schema(), dataOriginal.get(f.name()), schemaNew.field(f.name()).schema(),
-                      new Struct(schemaNew.field(f.name()).schema()), updatedPath));
+              targetStruct.put(targetSchema.field(field.name()),
+                  matchFields(rootRecord, field.schema(), (Struct) sourceStruct.get(field.name()),
+                      targetSchema.field(field.name()).schema(), new Struct(targetSchema.field(field.name()).schema()), updatedPath));
             } else {
               LOGGER.trace("value of {} field was null -> skip element-wise sub-field matching", Type.STRUCT);
             }
           } else {
-            LOGGER.trace("processing primitive field of type {}", f.schema().type());
-            dataNew.put(schemaNew.field(f.name()), processField(dataOriginal.get(f.name()), updatedPath, f.schema()));
+            LOGGER.trace("processing primitive field of type {}", field.schema().type());
+            targetStruct.put(targetSchema.field(field.name()), processField(rootRecord,
+                sourceStruct.get(field.name()), updatedPath, field.schema()));
           }
         } else {
-          LOGGER.trace("processing field of type {}", f.schema().type());
-          dataNew.put(schemaNew.field(f.name()), processField(dataOriginal.get(f.name()), updatedPath, f.schema()));
+          LOGGER.trace("processing field of type {}", field.schema().type());
+          targetStruct.put(targetSchema.field(field.name()), processField(rootRecord,
+              sourceStruct.get(field.name()), updatedPath, field.schema()));
         }
       } else {
         LOGGER.trace("copying non-matched field '{}'", updatedPath);
-        dataNew.put(schemaNew.field(f.name()), dataOriginal.get(f.name()));
+        targetStruct.put(targetSchema.field(field.name()), sourceStruct.get(field.name()));
       }
     });
-    return dataNew;
+    return targetStruct;
   }
 
-  private Object processField(Object object, String matchedPath, Schema connectSchema) {
+  private Object processField(Struct rootRecord, Object fieldValue, String matchedPath, Schema connectSchema) {
     try {
       LOGGER.debug("{} field {}", handler.cipherMode, matchedPath);
-      var fieldMetaData = handler.determineFieldMetaData(object, matchedPath);
+      var fieldMetaData = handler.determineFieldMetaData(rootRecord, fieldValue, matchedPath);
       LOGGER.trace("field meta-data for path '{}' {}", matchedPath, fieldMetaData);
       if (CipherMode.ENCRYPT == handler.cipherMode) {
         if (handler.isCipherFPE(fieldMetaData)) {
-          return handler.encryptFPE(object, fieldMetaData);
+          return handler.encryptFPE(fieldValue, fieldMetaData);
         }
         var serdeName = handler.getConfig().getString(KryptoniteSettings.SERDE_TYPE);
-        var canonical = fieldConverter.toCanonical(object, connectSchema, matchedPath, serdeName);
+        var canonical = fieldConverter.toCanonical(fieldValue, connectSchema, matchedPath, serdeName);
         return handler.encryptNonFPE(canonical, fieldMetaData);
       } else {
         if (handler.isCipherFPE(fieldMetaData)) {
-          return handler.decryptFPE(object, fieldMetaData);
+          return handler.decryptFPE(fieldValue, fieldMetaData);
         }
-        var decrypted = handler.decryptNonFPE(object);
+        var decrypted = handler.decryptNonFPE(fieldValue);
         return getCachedSchema(matchedPath)
             .or(() -> handler.resolveElementModeParentPath(matchedPath).flatMap(this::getCachedSchema))
             .map(schema -> {
@@ -125,28 +137,28 @@ public class SchemaawareRecordHandler implements FieldPathMatcher {
             });
       }
     } catch (Exception e) {
-      throw new DataException("error: " + handler.cipherMode + " of field path '" + matchedPath + "' having data '" + object + "' failed unexpectedly", e);
+      throw new DataException("error: " + handler.cipherMode + " of field path '" + matchedPath + "' having data '" + fieldValue + "' failed unexpectedly", e);
     }
   }
 
-  private List<?> processListField(List<?> list, String matchedPath, Schema elementSchema) {
-    return list.stream().map(e -> {
-      if (e instanceof List) return processListField((List<?>) e, matchedPath, elementSchema);
-      if (e instanceof Map) return processMapField((Map<?, ?>) e, matchedPath, elementSchema);
-      return processField(e, matchedPath, elementSchema);
+  private List<?> processListField(Struct rootRecord, List<?> fieldValues, String matchedPath, Schema elementSchema) {
+    return fieldValues.stream().map(elementValue -> {
+      if (elementValue instanceof List) return processListField(rootRecord, (List<?>) elementValue, matchedPath, elementSchema);
+      if (elementValue instanceof Map) return processMapField(rootRecord, (Map<?, ?>) elementValue, matchedPath, elementSchema);
+      return processField(rootRecord, elementValue, matchedPath, elementSchema);
     }).collect(Collectors.toList());
   }
 
-  private Map<?, ?> processMapField(Map<?, ?> map, String matchedPath, Schema valueSchema) {
-    return map.entrySet().stream()
-        .map(e -> {
-          var pathUpdate = matchedPath + handler.pathDelimiter + e.getKey();
-          if (e.getValue() instanceof List)
-            return new AbstractMap.SimpleEntry<>(e.getKey(), processListField((List<?>) e.getValue(), pathUpdate, valueSchema));
-          if (e.getValue() instanceof Map)
-            return new AbstractMap.SimpleEntry<>(e.getKey(), processMapField((Map<?, ?>) e.getValue(), pathUpdate, valueSchema));
-          return new AbstractMap.SimpleEntry<>(e.getKey(), processField(e.getValue(), pathUpdate, valueSchema));
-        }).collect(LinkedHashMap::new, (lhm, e) -> lhm.put(e.getKey(), e.getValue()), HashMap::putAll);
+  private Map<?, ?> processMapField(Struct rootRecord, Map<?, ?> fieldValues, String matchedPath, Schema valueSchema) {
+    return fieldValues.entrySet().stream()
+        .map(entry -> {
+          var pathUpdate = matchedPath + handler.pathDelimiter + entry.getKey();
+          if (entry.getValue() instanceof List)
+            return new AbstractMap.SimpleEntry<>(entry.getKey(), processListField(rootRecord, (List<?>) entry.getValue(), pathUpdate, valueSchema));
+          if (entry.getValue() instanceof Map)
+            return new AbstractMap.SimpleEntry<>(entry.getKey(), processMapField(rootRecord, (Map<?, ?>) entry.getValue(), pathUpdate, valueSchema));
+          return new AbstractMap.SimpleEntry<>(entry.getKey(), processField(rootRecord, entry.getValue(), pathUpdate, valueSchema));
+        }).collect(LinkedHashMap::new, (lhm, entry) -> lhm.put(entry.getKey(), entry.getValue()), HashMap::putAll);
   }
 
   private Optional<Schema> getCachedSchema(String fieldPath) {

--- a/connect-transform-kryptonite/src/main/java/com/github/hpgrahsl/kafka/connect/transforms/kryptonite/SchemalessRecordHandler.java
+++ b/connect-transform-kryptonite/src/main/java/com/github/hpgrahsl/kafka/connect/transforms/kryptonite/SchemalessRecordHandler.java
@@ -48,80 +48,80 @@ public class SchemalessRecordHandler implements FieldPathMatcher {
 
   @SuppressWarnings("unchecked")
   @Override
-  public Object matchFields(Schema schemaOriginal, Object objectOriginal, Schema schemaNew,
-      Object objectNew, String matchedPath) {
-    LOGGER.trace("checking fields in record {}", objectOriginal);
-    var dataOriginal = (Map<String, Object>) objectOriginal;
-    var dataNew = (Map<String, Object>) objectNew;
-    dataOriginal.forEach((f, v) -> {
-      var updatedPath = matchedPath.isEmpty() ? f : matchedPath + recordHandler.pathDelimiter + f;
+  public Object matchFields(Schema sourceSchema, Object sourceRecord, Schema targetSchema,
+      Object targetRecord, String matchedPath) {
+    LOGGER.trace("checking fields in record {}", sourceRecord);
+    var sourceMap = (Map<String, Object>) sourceRecord;
+    var targetMap = (Map<String, Object>) targetRecord;
+    sourceMap.forEach((fieldName, fieldValue) -> {
+      var updatedPath = matchedPath.isEmpty() ? fieldName : matchedPath + recordHandler.pathDelimiter + fieldName;
       var fc = recordHandler.fieldConfig.get(updatedPath);
       if (fc != null) {
         LOGGER.trace("matched field '{}'", updatedPath);
         if (FieldMode.ELEMENT == fc.getFieldMode()
             .orElse(FieldMode.valueOf(recordHandler.getConfig().getString(KryptoniteSettings.FIELD_MODE)))) {
-          if (v instanceof List) {
+          if (fieldValue instanceof List) {
             LOGGER.trace("processing {} field element-wise", List.class.getSimpleName());
-            dataNew.put(f, processListField((List<?>) dataOriginal.get(f), updatedPath));
-          } else if (v instanceof Map) {
+            targetMap.put(fieldName, processListField(sourceMap, (List<?>) sourceMap.get(fieldName), updatedPath));
+          } else if (fieldValue instanceof Map) {
             LOGGER.trace("processing {} field element-wise", Map.class.getSimpleName());
-            dataNew.put(f, processMapField((Map<?, ?>) dataOriginal.get(f), updatedPath));
+            targetMap.put(fieldName, processMapField(sourceMap, (Map<?, ?>) sourceMap.get(fieldName), updatedPath));
           } else {
             LOGGER.trace("processing primitive field");
-            dataNew.put(f, processField(dataOriginal.get(f), updatedPath));
+            targetMap.put(fieldName, processField(sourceMap, sourceMap.get(fieldName), updatedPath));
           }
         } else {
           LOGGER.trace("processing field");
-          dataNew.put(f, processField(dataOriginal.get(f), updatedPath));
+          targetMap.put(fieldName, processField(sourceMap, sourceMap.get(fieldName), updatedPath));
         }
       } else {
         LOGGER.trace("copying non-matched field '{}'", updatedPath);
-        dataNew.put(f, dataOriginal.get(f));
+        targetMap.put(fieldName, sourceMap.get(fieldName));
       }
     });
-    return dataNew;
+    return targetMap;
   }
 
-  private Object processField(Object object, String matchedPath) {
+  private Object processField(Map<String, Object> rootRecord, Object fieldValue, String matchedPath) {
     try {
       LOGGER.debug("{} field {}", recordHandler.cipherMode, matchedPath);
-      var fieldMetaData = recordHandler.determineFieldMetaData(object, matchedPath);
+      var fieldMetaData = recordHandler.determineFieldMetaData(rootRecord, fieldValue, matchedPath);
       LOGGER.trace("field meta-data for path '{}' {}", matchedPath, fieldMetaData);
       if (CipherMode.ENCRYPT == recordHandler.cipherMode) {
         if (recordHandler.isCipherFPE(fieldMetaData)) {
-          return recordHandler.encryptFPE(object, fieldMetaData);
+          return recordHandler.encryptFPE(fieldValue, fieldMetaData);
         }
-        var converted = fieldConverter.toCanonical(object, matchedPath, recordHandler.getConfig().getString(KryptoniteSettings.SERDE_TYPE));
+        var converted = fieldConverter.toCanonical(fieldValue, matchedPath, recordHandler.getConfig().getString(KryptoniteSettings.SERDE_TYPE));
         return recordHandler.encryptNonFPE(converted, fieldMetaData);
       } else {
         if (recordHandler.isCipherFPE(fieldMetaData)) {
-          return recordHandler.decryptFPE(object, fieldMetaData);
+          return recordHandler.decryptFPE(fieldValue, fieldMetaData);
         }
-        return fieldConverter.fromCanonical(recordHandler.decryptNonFPE(object));
+        return fieldConverter.fromCanonical(recordHandler.decryptNonFPE(fieldValue));
       }
     } catch (Exception e) {
-      throw new DataException("error: " + recordHandler.cipherMode + " of field path '" + matchedPath + "' having data '" + object + "' failed unexpectedly", e);
+      throw new DataException("error: " + recordHandler.cipherMode + " of field path '" + matchedPath + "' having data '" + fieldValue + "' failed unexpectedly", e);
     }
   }
 
-  private List<?> processListField(List<?> list, String matchedPath) {
-    return list.stream().map(e -> {
-      if (e instanceof List) return processListField((List<?>) e, matchedPath);
-      if (e instanceof Map) return processMapField((Map<?, ?>) e, matchedPath);
-      return processField(e, matchedPath);
+  private List<?> processListField(Map<String, Object> rootRecord, List<?> fieldValues, String matchedPath) {
+    return fieldValues.stream().map(elementValue -> {
+      if (elementValue instanceof List) return processListField(rootRecord, (List<?>) elementValue, matchedPath);
+      if (elementValue instanceof Map) return processMapField(rootRecord, (Map<?, ?>) elementValue, matchedPath);
+      return processField(rootRecord, elementValue, matchedPath);
     }).collect(Collectors.toList());
   }
 
-  private Map<?, ?> processMapField(Map<?, ?> map, String matchedPath) {
-    return map.entrySet().stream()
-        .map(e -> {
-          var pathUpdate = matchedPath + recordHandler.pathDelimiter + e.getKey();
-          if (e.getValue() instanceof List)
-            return new AbstractMap.SimpleEntry<>(e.getKey(), processListField((List<?>) e.getValue(), pathUpdate));
-          if (e.getValue() instanceof Map)
-            return new AbstractMap.SimpleEntry<>(e.getKey(), processMapField((Map<?, ?>) e.getValue(), pathUpdate));
-          return new AbstractMap.SimpleEntry<>(e.getKey(), processField(e.getValue(), pathUpdate));
-        }).collect(LinkedHashMap::new, (lhm, e) -> lhm.put(e.getKey(), e.getValue()), HashMap::putAll);
+  private Map<?, ?> processMapField(Map<String, Object> rootRecord, Map<?, ?> fieldValues, String matchedPath) {
+    return fieldValues.entrySet().stream()
+        .map(entry -> {
+          var pathUpdate = matchedPath + recordHandler.pathDelimiter + entry.getKey();
+          if (entry.getValue() instanceof List)
+            return new AbstractMap.SimpleEntry<>(entry.getKey(), processListField(rootRecord, (List<?>) entry.getValue(), pathUpdate));
+          if (entry.getValue() instanceof Map)
+            return new AbstractMap.SimpleEntry<>(entry.getKey(), processMapField(rootRecord, (Map<?, ?>) entry.getValue(), pathUpdate));
+          return new AbstractMap.SimpleEntry<>(entry.getKey(), processField(rootRecord, entry.getValue(), pathUpdate));
+        }).collect(LinkedHashMap::new, (lhm, entry) -> lhm.put(entry.getKey(), entry.getValue()), HashMap::putAll);
   }
 
 }

--- a/connect-transform-kryptonite/src/test/java/com/github/hpgrahsl/kafka/connect/transforms/kryptonite/DynamicKeyIdResolverTest.java
+++ b/connect-transform-kryptonite/src/test/java/com/github/hpgrahsl/kafka/connect/transforms/kryptonite/DynamicKeyIdResolverTest.java
@@ -1,0 +1,312 @@
+package com.github.hpgrahsl.kafka.connect.transforms.kryptonite;
+
+import com.github.hpgrahsl.kryptonite.config.KryptoniteSettings;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("DynamicKeyIdResolver")
+class DynamicKeyIdResolverTest {
+
+    private static AbstractConfig config(Map<String, String> overrides) {
+        var props = new LinkedHashMap<String, String>();
+        props.put(KryptoniteSettings.FIELD_CONFIG, "[{\"name\":\"dummy\"}]");
+        props.put(KryptoniteSettings.CIPHER_MODE, "ENCRYPT");
+        props.put(KryptoniteSettings.CIPHER_ALGORITHM, "TINK/AES_GCM");
+        props.put(KryptoniteSettings.CIPHER_DATA_KEY_IDENTIFIER, "default-key");
+        props.put(KryptoniteSettings.DYNAMIC_KEY_ID_PREFIX, "__#");
+        props.put(KryptoniteSettings.PATH_DELIMITER, ".");
+        props.putAll(overrides);
+        return new SimpleConfig(CipherField.CONFIG_DEF, props);
+    }
+
+    @Nested
+    @DisplayName("Map root record")
+    class MapRootRecord {
+
+        @Test
+        @DisplayName("returns static field-level key id unchanged")
+        void returnsStaticFieldLevelKeyId() {
+            var cfg = config(Map.of());
+            var fc = FieldConfig.builder().name("id").keyId("explicit-key").build();
+
+            assertEquals("explicit-key", DynamicKeyIdResolver.resolve(fc, cfg, mapRoot("de", "eu", "hello json")));
+        }
+
+        @Test
+        @DisplayName("resolves dynamic default key id")
+        void resolvesDynamicDefaultKeyId() {
+            var cfg = config(Map.of(KryptoniteSettings.CIPHER_DATA_KEY_IDENTIFIER, "__#mySubDoc1.myString"));
+            var fc = FieldConfig.builder().name("id").build();
+
+            assertEquals("hello json", DynamicKeyIdResolver.resolve(fc, cfg, mapRoot("de", "eu", "hello json")));
+        }
+
+        @Test
+        @DisplayName("resolves dynamic field-level key id")
+        void resolvesDynamicFieldLevelKeyId() {
+            var cfg = config(Map.of());
+            var fc = FieldConfig.builder().name("id").keyId("__#myString").build();
+
+            assertEquals("some foo bla text", DynamicKeyIdResolver.resolve(fc, cfg, mapRoot("de", "eu", "hello json")));
+        }
+
+        @Test
+        @DisplayName("resolves dynamic envelope KEK fallback for KMS envelope")
+        void resolvesDynamicEnvelopeKekFallbackForKmsEnvelope() {
+            var cfg = config(Map.of(
+                    KryptoniteSettings.CIPHER_DATA_KEY_IDENTIFIER, "ignored-data-key",
+                    KryptoniteSettings.ENVELOPE_KEK_IDENTIFIER, "__#myString"));
+            var fc = FieldConfig.builder().name("id").algorithm("TINK/AES_GCM_ENVELOPE_KMS").build();
+
+            assertEquals("some foo bla text", DynamicKeyIdResolver.resolve(fc, cfg, mapRoot("de", "eu", "hello json")));
+        }
+
+        @Test
+        @DisplayName("prefers field-level key id over envelope KEK fallback for KMS envelope")
+        void prefersFieldLevelKeyIdOverEnvelopeKekFallbackForKmsEnvelope() {
+            var cfg = config(Map.of(
+                    KryptoniteSettings.ENVELOPE_KEK_IDENTIFIER, "__#myString"));
+            var fc = FieldConfig.builder().name("id").algorithm("TINK/AES_GCM_ENVELOPE_KMS").keyId("__#mySubDoc1.myString").build();
+
+            assertEquals("hello json", DynamicKeyIdResolver.resolve(fc, cfg, mapRoot("de", "eu", "hello json")));
+        }
+
+        @Test
+        @DisplayName("resolves path through map to nested struct")
+        void resolvesPathThroughMapToNestedStruct() {
+            var cfg = config(Map.of(KryptoniteSettings.CIPHER_DATA_KEY_IDENTIFIER, "__#mySubDoc2.nested.code"));
+            var fc = FieldConfig.builder().name("id").build();
+            var rootRecord = new LinkedHashMap<>(mapRoot("de", "eu", "hello json"));
+            rootRecord.put("mySubDoc2", Map.of("nested", structNested("dk"), "k1", 9));
+
+            assertEquals("dk", DynamicKeyIdResolver.resolve(fc, cfg, rootRecord));
+        }
+
+        @Test
+        @DisplayName("throws when field path is missing")
+        void throwsWhenFieldPathIsMissing() {
+            var cfg = config(Map.of(KryptoniteSettings.CIPHER_DATA_KEY_IDENTIFIER, "__#missing.path"));
+            var fc = FieldConfig.builder().name("id").build();
+
+            var exception = assertThrows(DataException.class,
+                    () -> DynamicKeyIdResolver.resolve(fc, cfg, mapRoot("de", "eu", "hello json")));
+            assertEquals("Dynamic key identifier resolution failed for field path 'missing.path': an intermediate path segment was missing or did not resolve to a structured object", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("throws when resolved value is not a string")
+        void throwsWhenResolvedValueIsNotAString() {
+            var cfg = config(Map.of(KryptoniteSettings.CIPHER_DATA_KEY_IDENTIFIER, "__#mySubDoc2.k1"));
+            var fc = FieldConfig.builder().name("id").build();
+
+            var exception = assertThrows(DataException.class,
+                    () -> DynamicKeyIdResolver.resolve(fc, cfg, mapRoot("de", "eu", "hello json")));
+            assertEquals("Dynamic key identifier resolution failed for field path 'k1': resolved to type Integer but a string value is required", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("throws when resolved value is blank")
+        void throwsWhenResolvedValueIsBlank() {
+            var cfg = config(Map.of(KryptoniteSettings.CIPHER_DATA_KEY_IDENTIFIER, "__#mySubDoc1.myString"));
+            var fc = FieldConfig.builder().name("id").build();
+
+            var exception = assertThrows(DataException.class,
+                    () -> DynamicKeyIdResolver.resolve(fc, cfg, mapRoot("de", "eu", "   ")));
+            assertEquals("Dynamic key identifier resolution failed for expression '__#mySubDoc1.myString': field path 'mySubDoc1.myString' resolved to a blank string but a non-blank key id is required", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("throws when dynamic expression has no suffix after prefix")
+        void throwsWhenDynamicExpressionHasNoSuffix() {
+            var cfg = config(Map.of(KryptoniteSettings.CIPHER_DATA_KEY_IDENTIFIER, "__#"));
+            var fc = FieldConfig.builder().name("id").build();
+
+            var exception = assertThrows(DataException.class,
+                    () -> DynamicKeyIdResolver.resolve(fc, cfg, mapRoot("de", "eu", "hello json")));
+            assertEquals("Dynamic key identifier '__#' has no field path after prefix '__#'", exception.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("Struct root record")
+    class StructRootRecord {
+
+        @Test
+        @DisplayName("returns static field-level key id unchanged")
+        void returnsStaticFieldLevelKeyId() {
+            var cfg = config(Map.of());
+            var fc = FieldConfig.builder().name("id").keyId("explicit-key").build();
+
+            assertEquals("explicit-key", DynamicKeyIdResolver.resolve(fc, cfg, structRoot("de", "eu", "hello json")));
+        }
+
+        @Test
+        @DisplayName("resolves dynamic default key id")
+        void resolvesDynamicDefaultKeyId() {
+            var cfg = config(Map.of(KryptoniteSettings.CIPHER_DATA_KEY_IDENTIFIER, "__#mySubDoc1.myString"));
+            var fc = FieldConfig.builder().name("id").build();
+
+            assertEquals("hello json", DynamicKeyIdResolver.resolve(fc, cfg, structRoot("de", "eu", "hello json")));
+        }
+
+        @Test
+        @DisplayName("resolves dynamic field-level key id")
+        void resolvesDynamicFieldLevelKeyId() {
+            var cfg = config(Map.of());
+            var fc = FieldConfig.builder().name("id").keyId("__#myString").build();
+
+            assertEquals("some foo bla text", DynamicKeyIdResolver.resolve(fc, cfg, structRoot("de", "eu", "hello json")));
+        }
+
+        @Test
+        @DisplayName("resolves dynamic envelope KEK fallback for KMS envelope")
+        void resolvesDynamicEnvelopeKekFallbackForKmsEnvelope() {
+            var cfg = config(Map.of(
+                    KryptoniteSettings.CIPHER_DATA_KEY_IDENTIFIER, "ignored-data-key",
+                    KryptoniteSettings.ENVELOPE_KEK_IDENTIFIER, "__#myString"));
+            var fc = FieldConfig.builder().name("id").algorithm("TINK/AES_GCM_ENVELOPE_KMS").build();
+
+            assertEquals("some foo bla text", DynamicKeyIdResolver.resolve(fc, cfg, structRoot("de", "eu", "hello json")));
+        }
+
+        @Test
+        @DisplayName("prefers field-level key id over envelope KEK fallback for KMS envelope")
+        void prefersFieldLevelKeyIdOverEnvelopeKekFallbackForKmsEnvelope() {
+            var cfg = config(Map.of(
+                    KryptoniteSettings.ENVELOPE_KEK_IDENTIFIER, "__#myString"));
+            var fc = FieldConfig.builder().name("id").algorithm("TINK/AES_GCM_ENVELOPE_KMS").keyId("__#mySubDoc1.myString").build();
+
+            assertEquals("hello json", DynamicKeyIdResolver.resolve(fc, cfg, structRoot("de", "eu", "hello json")));
+        }
+
+        @Test
+        @DisplayName("resolves path through struct to nested map to nested struct")
+        void resolvesPathThroughStructToNestedMapToNestedStruct() {
+            var cfg = config(Map.of(KryptoniteSettings.CIPHER_DATA_KEY_IDENTIFIER, "__#mySubDoc2.nested.code"));
+            var fc = FieldConfig.builder().name("id").build();
+
+            assertEquals("dk", DynamicKeyIdResolver.resolve(fc, cfg, structRootWithNestedStructInMap("de", "eu", "hello json", "dk")));
+        }
+
+        @Test
+        @DisplayName("throws when field path is missing")
+        void throwsWhenFieldPathIsMissing() {
+            var cfg = config(Map.of(KryptoniteSettings.CIPHER_DATA_KEY_IDENTIFIER, "__#missing.path"));
+            var fc = FieldConfig.builder().name("id").build();
+
+            var exception = assertThrows(DataException.class,
+                    () -> DynamicKeyIdResolver.resolve(fc, cfg, structRoot("de", "eu", "hello json")));
+            assertEquals("Dynamic key identifier resolution failed for field path 'missing.path': an intermediate path segment was missing or did not resolve to a structured object", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("throws when resolved value is not a string")
+        void throwsWhenResolvedValueIsNotAString() {
+            var cfg = config(Map.of(KryptoniteSettings.CIPHER_DATA_KEY_IDENTIFIER, "__#mySubDoc2.k1"));
+            var fc = FieldConfig.builder().name("id").build();
+
+            var exception = assertThrows(DataException.class,
+                    () -> DynamicKeyIdResolver.resolve(fc, cfg, structRoot("de", "eu", "hello json")));
+            assertEquals("Dynamic key identifier resolution failed for field path 'k1': resolved to type Integer but a string value is required", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("throws when resolved value is blank")
+        void throwsWhenResolvedValueIsBlank() {
+            var cfg = config(Map.of(KryptoniteSettings.CIPHER_DATA_KEY_IDENTIFIER, "__#mySubDoc1.myString"));
+            var fc = FieldConfig.builder().name("id").build();
+
+            var exception = assertThrows(DataException.class,
+                    () -> DynamicKeyIdResolver.resolve(fc, cfg, structRoot("de", "eu", "   ")));
+            assertEquals("Dynamic key identifier resolution failed for expression '__#mySubDoc1.myString': field path 'mySubDoc1.myString' resolved to a blank string but a non-blank key id is required", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("throws when dynamic expression has no suffix after prefix")
+        void throwsWhenDynamicExpressionHasNoSuffix() {
+            var cfg = config(Map.of(KryptoniteSettings.CIPHER_DATA_KEY_IDENTIFIER, "__#"));
+            var fc = FieldConfig.builder().name("id").build();
+
+            var exception = assertThrows(DataException.class,
+                    () -> DynamicKeyIdResolver.resolve(fc, cfg, structRoot("de", "eu", "hello json")));
+            assertEquals("Dynamic key identifier '__#' has no field path after prefix '__#'", exception.getMessage());
+        }
+    }
+
+    private static Map<String, Object> mapRoot(String country, String region, String nestedString) {
+        return new LinkedHashMap<>(Map.of(
+                "id", "1234567890",
+                "myString", "some foo bla text",
+                "mySubDoc1", Map.of("country", country, "region", region, "myString", nestedString),
+                "mySubDoc2", Map.of("k1", 9, "k2", 8),
+                "myArray1", List.of("str_1", "str_2")
+        ));
+    }
+
+    private static Struct structNested(String code) {
+        var nestedSchema = SchemaBuilder.struct()
+                .field("code", org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
+                .build();
+        return new Struct(nestedSchema).put("code", code);
+    }
+
+    private static Struct structRoot(String country, String region, String nestedString) {
+        var subSchema = SchemaBuilder.struct()
+                .field("country", org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
+                .field("region", org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
+                .field("myString", org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
+                .build();
+        var schema = SchemaBuilder.struct()
+                .field("id", org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
+                .field("myString", org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
+                .field("mySubDoc1", subSchema)
+                .field("mySubDoc2", SchemaBuilder.map(org.apache.kafka.connect.data.Schema.STRING_SCHEMA, org.apache.kafka.connect.data.Schema.INT32_SCHEMA).build())
+                .build();
+        return new Struct(schema)
+                .put("id", "1234567890")
+                .put("myString", "some foo bla text")
+                .put("mySubDoc1", new Struct(subSchema)
+                        .put("country", country)
+                        .put("region", region)
+                        .put("myString", nestedString))
+                .put("mySubDoc2", Map.of("k1", 9, "k2", 8));
+    }
+
+    private static Struct structRootWithNestedStructInMap(String country, String region, String nestedString, String nestedCode) {
+        var subSchema = SchemaBuilder.struct()
+                .field("country", org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
+                .field("region", org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
+                .field("myString", org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
+                .build();
+        var nestedSchema = SchemaBuilder.struct()
+                .field("code", org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
+                .build();
+        var schema = SchemaBuilder.struct()
+                .field("id", org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
+                .field("myString", org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
+                .field("mySubDoc1", subSchema)
+                .field("mySubDoc2", SchemaBuilder.map(org.apache.kafka.connect.data.Schema.STRING_SCHEMA, nestedSchema).build())
+                .build();
+        return new Struct(schema)
+                .put("id", "1234567890")
+                .put("myString", "some foo bla text")
+                .put("mySubDoc1", new Struct(subSchema)
+                        .put("country", country)
+                        .put("region", region)
+                        .put("myString", nestedString))
+                .put("mySubDoc2", Map.of("nested", structNested(nestedCode)));
+    }
+}

--- a/funqy-http-kryptonite/src/main/java/com/github/hpgrahsl/funqy/http/kryptonite/KryptoniteConfiguration.java
+++ b/funqy-http-kryptonite/src/main/java/com/github/hpgrahsl/funqy/http/kryptonite/KryptoniteConfiguration.java
@@ -124,6 +124,7 @@ public class KryptoniteConfiguration {
         kc.cipherFpeAlphabetType = cipherFpeAlphabetType;
         kc.cipherFpeAlphabetCustom = Optional.of(cipherFpeAlphabetCustom);
         kc.keySource = keySource;
+        kc.kmsType = kmsType;
         kc.kmsConfig = kmsConfig;
         kc.kekType = kekType;
         kc.kekConfig = kekConfig;

--- a/funqy-http-kryptonite/src/main/java/com/github/hpgrahsl/funqy/http/kryptonite/RecordHandler.java
+++ b/funqy-http-kryptonite/src/main/java/com/github/hpgrahsl/funqy/http/kryptonite/RecordHandler.java
@@ -159,42 +159,70 @@ public class RecordHandler {
   }
 
   private FieldMetaData determineFieldMetaData(Map<String,Object> objectOriginal, Object object, String fieldPath) {
-    
-    var fieldMetaData = Optional.ofNullable(fieldConfig.get(fieldPath))
-          .map(fc -> 
-            FieldMetaData.builder()
-              .algorithm(fc.getAlgorithm().orElseGet(() -> config.cipherAlgorithm))
-              .dataType(Optional.ofNullable(object).map(o -> o.getClass().getName()).orElse(""))
-              .keyId(fc.getKeyId().orElseGet(() -> config.cipherDataKeyIdentifier))
-              .fpeTweak(fc.getFpeTweak().orElseGet(() -> config.cipherFpeTweak))
-              .fpeAlphabet(determineAlphabetFromFieldConfig(fc))
-              .encoding(fc.getEncoding().orElse(config.cipherTextEncoding))
-              .build()
-        ).orElseGet(
-            () -> FieldMetaData.builder()
-              .algorithm(config.cipherAlgorithm)
-              .dataType(Optional.ofNullable(object).map(o -> o.getClass().getName()).orElse(""))
-              .keyId(config.cipherDataKeyIdentifier)
-              .fpeTweak(config.cipherFpeTweak)
-              .fpeAlphabet(getAlphabetFromGlobalConfig())
-              .encoding(config.cipherTextEncoding)
-              .build()
-        );  
-    
-    if(!fieldMetaData.getKeyId().startsWith(config.dynamicKeyIdPrefix)) {
-        return fieldMetaData;
+    var fc = fieldConfig.get(fieldPath);
+    var algorithm = Optional.ofNullable(fc)
+        .flatMap(FieldConfig::getAlgorithm)
+        .orElse(config.cipherAlgorithm);
+    var configuredKeyId = Optional.ofNullable(fc)
+        .map(cfg -> determineConfiguredKeyId(cfg, algorithm))
+        .orElseGet(() -> determineDefaultConfiguredKeyId(algorithm));
+
+    var fieldMetaData = Optional.ofNullable(fc)
+        .map(cfg -> FieldMetaData.builder()
+            .algorithm(algorithm)
+            .dataType(Optional.ofNullable(object).map(o -> o.getClass().getName()).orElse(""))
+            .keyId(configuredKeyId)
+            .fpeTweak(cfg.getFpeTweak().orElseGet(() -> config.cipherFpeTweak))
+            .fpeAlphabet(determineAlphabetFromFieldConfig(cfg))
+            .encoding(cfg.getEncoding().orElse(config.cipherTextEncoding))
+            .build())
+        .orElseGet(() -> FieldMetaData.builder()
+            .algorithm(algorithm)
+            .dataType(Optional.ofNullable(object).map(o -> o.getClass().getName()).orElse(""))
+            .keyId(configuredKeyId)
+            .fpeTweak(config.cipherFpeTweak)
+            .fpeAlphabet(getAlphabetFromGlobalConfig())
+            .encoding(config.cipherTextEncoding)
+            .build());
+
+    return resolveDynamicKeyIdIfNeeded(objectOriginal, fieldMetaData);
+  }
+
+  private String determineConfiguredKeyId(FieldConfig fieldConfig, String algorithm) {
+    return fieldConfig.getKeyId().orElseGet(() -> determineDefaultConfiguredKeyId(algorithm));
+  }
+
+  private String determineDefaultConfiguredKeyId(String algorithm) {
+    var cipherSpec = CipherSpec.fromName(algorithm.toUpperCase());
+    return cipherSpec instanceof Kryptonite.KmsEnvelopeCipherSpec
+        ? config.envelopeKekIdentifier
+        : config.cipherDataKeyIdentifier;
+  }
+
+  private FieldMetaData resolveDynamicKeyIdIfNeeded(Map<String, Object> objectOriginal, FieldMetaData fieldMetaData) {
+    var configuredKeyId = fieldMetaData.getKeyId();
+    if (!configuredKeyId.startsWith(config.dynamicKeyIdPrefix)) {
+      return fieldMetaData;
     }
 
-    var extractedKeyIdentifier = extractKeyIdentifierFromPayload(objectOriginal, fieldMetaData.getKeyId().replace(config.dynamicKeyIdPrefix, ""));
-    
+    var fieldPath = configuredKeyId.substring(config.dynamicKeyIdPrefix.length());
+    if (fieldPath.isBlank()) {
+      throw new IllegalStateException("error: dynamic key identifier has no field path after prefix '" + config.dynamicKeyIdPrefix + "'");
+    }
+
+    var extractedKeyIdentifier = extractKeyIdentifierFromPayload(objectOriginal, fieldPath);
+    if (extractedKeyIdentifier.isBlank()) {
+      throw new IllegalStateException("error: dynamic key identifier extraction failed -> resolved to a blank string");
+    }
+
     return FieldMetaData.builder()
-      .algorithm(fieldMetaData.getAlgorithm())
-      .dataType(fieldMetaData.getDataType())
-      .keyId(extractedKeyIdentifier.orElseGet(() -> config.cipherDataKeyIdentifier))
-      .fpeTweak(fieldMetaData.getFpeTweak())
-      .fpeAlphabet(fieldMetaData.getFpeAlphabet())
-      .encoding(fieldMetaData.getEncoding())
-      .build();
+        .algorithm(fieldMetaData.getAlgorithm())
+        .dataType(fieldMetaData.getDataType())
+        .keyId(extractedKeyIdentifier)
+        .fpeTweak(fieldMetaData.getFpeTweak())
+        .fpeAlphabet(fieldMetaData.getFpeAlphabet())
+        .encoding(fieldMetaData.getEncoding())
+        .build();
   }
 
   private String determineAlphabetFromFieldConfig(FieldConfig fieldConfig) {
@@ -212,22 +240,23 @@ public class RecordHandler {
   }
  
   @SuppressWarnings("unchecked")
-  private Optional<String> extractKeyIdentifierFromPayload(Map<String, Object> payload, String fieldPath) {
+  private String extractKeyIdentifierFromPayload(Map<String, Object> payload, String fieldPath) {
     if(!fieldPath.contains(config.pathDelimiter)) {
       Object value = payload.get(fieldPath);
-      if(! (value instanceof String)) {
-        throw new RuntimeException("error: key identifier extraction failed"
-        + " -> either the dynamic key identifier has an invalid field path set or the payload itself doesn't contain the specified field(s)");
+      if(!(value instanceof String)) {
+        throw new IllegalStateException("error: key identifier extraction failed"
+            + " -> either the dynamic key identifier has an invalid field path set or the payload itself doesn't contain the specified field(s)");
       }
-      return Optional.of((String)value);
+      return (String) value;
     }
     String[] fields = fieldPath.split("\\"+config.pathDelimiter);
     Object field = payload.get(fields[0]);
     if(!(field instanceof Map)) {
-      throw new RuntimeException("error: key identifier extraction failed"
-      + " -> either the dynamic key identifier has an invalid field path set or the payload itself doesn't contain the specified field(s)");  
+      throw new IllegalStateException("error: key identifier extraction failed"
+          + " -> either the dynamic key identifier has an invalid field path set or the payload itself doesn't contain the specified field(s)");
     }
-    return extractKeyIdentifierFromPayload((Map<String,Object>)field, String.join(config.pathDelimiter, Arrays.copyOfRange(fields, 1, fields.length)));
+    return extractKeyIdentifierFromPayload((Map<String,Object>) field,
+        String.join(config.pathDelimiter, Arrays.copyOfRange(fields, 1, fields.length)));
   }
 
 }

--- a/kroxylicious-filter-kryptonite/src/main/java/com/github/hpgrahsl/kroxylicious/filters/kryptonite/config/KryptoniteFilterConfig.java
+++ b/kroxylicious-filter-kryptonite/src/main/java/com/github/hpgrahsl/kroxylicious/filters/kryptonite/config/KryptoniteFilterConfig.java
@@ -204,10 +204,6 @@ public class KryptoniteFilterConfig {
             }
         }
 
-        if (dynamicKeyIdPrefix == null || dynamicKeyIdPrefix.isBlank()) {
-            errors.add("dynamic_key_id_prefix must not be blank");
-        }
-
         if (!errors.isEmpty()) {
             throw new IllegalArgumentException(
                     "Invalid Kryptonite filter configuration (" + errors.size() + " error(s)):\n  - "

--- a/kroxylicious-filter-kryptonite/src/main/java/com/github/hpgrahsl/kroxylicious/filters/kryptonite/config/KryptoniteFilterConfig.java
+++ b/kroxylicious-filter-kryptonite/src/main/java/com/github/hpgrahsl/kroxylicious/filters/kryptonite/config/KryptoniteFilterConfig.java
@@ -51,6 +51,7 @@ public class KryptoniteFilterConfig {
     private final SchemaMode schemaMode;
 
     private final String serdeType;
+    private final String dynamicKeyIdPrefix;
 
     // --- Topic-to-field routing ---
     private final List<TopicFieldConfig> topicFieldConfigs;
@@ -81,6 +82,7 @@ public class KryptoniteFilterConfig {
             @JsonProperty(value = "record_format") RecordFormat recordFormat,
             @JsonProperty(value = "schema_mode") SchemaMode schemaMode,
             @JsonProperty(value = "serde_type") String serdeType,
+            @JsonProperty(value = "dynamic_key_id_prefix") String dynamicKeyIdPrefix,
             @JsonProperty(value = "topic_field_configs") List<TopicFieldConfig> topicFieldConfigs,
             @JsonProperty(value = "blocking_pool_size") int blockingPoolSize) {
         this.keySource = keySource != null ? keySource : KryptoniteSettings.KEY_SOURCE_DEFAULT;
@@ -105,6 +107,7 @@ public class KryptoniteFilterConfig {
         this.recordFormat = recordFormat;
         this.schemaMode = schemaMode != null ? schemaMode : SchemaMode.DYNAMIC;
         this.serdeType = serdeType != null ? serdeType : KryptoniteSettings.SERDE_TYPE_DEFAULT;
+        this.dynamicKeyIdPrefix = dynamicKeyIdPrefix != null ? dynamicKeyIdPrefix : KryptoniteSettings.DYNAMIC_KEY_ID_PREFIX_DEFAULT;
         this.topicFieldConfigs = topicFieldConfigs != null ? topicFieldConfigs : List.of();
         this.blockingPoolSize = blockingPoolSize;
     }
@@ -131,6 +134,7 @@ public class KryptoniteFilterConfig {
     public RecordFormat getRecordFormat() { return recordFormat; }
     public SchemaMode getSchemaMode() { return schemaMode; }
     public String getSerdeType() { return serdeType; }
+    public String getDynamicKeyIdPrefix() { return dynamicKeyIdPrefix; }
     public List<TopicFieldConfig> getTopicFieldConfigs() { return topicFieldConfigs; }
     public int getBlockingPoolSize() { return blockingPoolSize; }
 
@@ -198,6 +202,10 @@ public class KryptoniteFilterConfig {
                     errors.add("kek_uri is required when key_source is " + parsedKeySource);
                 }
             }
+        }
+
+        if (dynamicKeyIdPrefix == null || dynamicKeyIdPrefix.isBlank()) {
+            errors.add("dynamic_key_id_prefix must not be blank");
         }
 
         if (!errors.isEmpty()) {

--- a/kroxylicious-filter-kryptonite/src/main/java/com/github/hpgrahsl/kroxylicious/filters/kryptonite/processor/AbstractJsonRecordProcessor.java
+++ b/kroxylicious-filter-kryptonite/src/main/java/com/github/hpgrahsl/kroxylicious/filters/kryptonite/processor/AbstractJsonRecordProcessor.java
@@ -55,25 +55,26 @@ abstract class AbstractJsonRecordProcessor implements RecordValueProcessor {
             if (fieldValue == null) continue;
             JsonNode node = (JsonNode) fieldValue;
             FieldConfig.FieldMode mode = fc.getFieldMode().orElse(FieldConfig.DEFAULT_MODE);
+            String resolvedKeyId = DynamicKeyIdResolver.resolve(fc, config, accessor);
             if (mode == FieldConfig.FieldMode.ELEMENT && node.isNull()) {
                 LOG.warn("ELEMENT mode: field '{}' is null — skipping (cannot iterate null container)", fc.getName());
                 continue;
             }
             if (mode == FieldConfig.FieldMode.ELEMENT && node.isArray()) {
-                accessor.setField(fc.getName(), encryptArrayElements((ArrayNode) node, fc));
+                accessor.setField(fc.getName(), encryptArrayElements((ArrayNode) node, fc, null, resolvedKeyId));
             } else if (mode == FieldConfig.FieldMode.ELEMENT && node.isObject()) {
-                accessor.setField(fc.getName(), encryptObjectValues((ObjectNode) node, fc));
+                accessor.setField(fc.getName(), encryptObjectValues((ObjectNode) node, fc, null, resolvedKeyId));
             } else {
                 if (FieldConfigUtils.isFpe(fc, config)) {
                     if (!node.isTextual()) throw new IllegalStateException(
                             "FPE encryption requires a string value for field '" + fc.getName()
                             + "' but got JSON type " + node.getNodeType() + " — FPE cannot encrypt non-string types");
                     byte[] plaintext = node.asText().getBytes(StandardCharsets.UTF_8);
-                    byte[] ciphertext = kryptonite.cipherFieldFPE(plaintext, FieldConfigUtils.buildFieldMetaData(fc, config));
+                    byte[] ciphertext = kryptonite.cipherFieldFPE(plaintext, FieldConfigUtils.buildFieldMetaData(fc, config, resolvedKeyId));
                     accessor.setField(fc.getName(), new String(ciphertext, StandardCharsets.UTF_8));
                 } else {
                     accessor.setField(fc.getName(),
-                            FieldHandler.encryptField(fieldConverter.toCanonical(node, fc.getName(), serdeType), FieldConfigUtils.buildPayloadMetaData(fc, config), kryptonite, serdeType));
+                            FieldHandler.encryptField(fieldConverter.toCanonical(node, fc.getName(), serdeType), FieldConfigUtils.buildPayloadMetaData(fc, config, resolvedKeyId), kryptonite, serdeType));
                 }
             }
         }
@@ -96,25 +97,26 @@ abstract class AbstractJsonRecordProcessor implements RecordValueProcessor {
             JsonNode node = (JsonNode) fieldValue;
             FieldConfig.FieldMode mode = fc.getFieldMode().orElse(FieldConfig.DEFAULT_MODE);
             String schemaCacheKey = topicName + "." + fc.getName();
+            String resolvedKeyId = DynamicKeyIdResolver.resolve(fc, config, accessor);
             if (mode == FieldConfig.FieldMode.ELEMENT && node.isNull()) {
                 LOG.warn("ELEMENT mode: field '{}' is null — skipping (cannot iterate null container)", fc.getName());
                 continue;
             }
             if (mode == FieldConfig.FieldMode.ELEMENT && node.isArray()) {
-                accessor.setField(fc.getName(), encryptArrayElements((ArrayNode) node, fc, schemaCacheKey));
+                accessor.setField(fc.getName(), encryptArrayElements((ArrayNode) node, fc, schemaCacheKey, resolvedKeyId));
             } else if (mode == FieldConfig.FieldMode.ELEMENT && node.isObject()) {
-                accessor.setField(fc.getName(), encryptObjectValues((ObjectNode) node, fc, schemaCacheKey));
+                accessor.setField(fc.getName(), encryptObjectValues((ObjectNode) node, fc, schemaCacheKey, resolvedKeyId));
             } else {
                 if (FieldConfigUtils.isFpe(fc, config)) {
                     if (!node.isTextual()) throw new IllegalStateException(
                             "FPE encryption requires a string value for field '" + fc.getName()
                             + "' but got JSON type " + node.getNodeType() + " — FPE cannot encrypt non-string types");
                     byte[] plaintext = node.asText().getBytes(StandardCharsets.UTF_8);
-                    byte[] ciphertext = kryptonite.cipherFieldFPE(plaintext, FieldConfigUtils.buildFieldMetaData(fc, config));
+                    byte[] ciphertext = kryptonite.cipherFieldFPE(plaintext, FieldConfigUtils.buildFieldMetaData(fc, config, resolvedKeyId));
                     accessor.setField(fc.getName(), new String(ciphertext, StandardCharsets.UTF_8));
                 } else {
                     accessor.setField(fc.getName(),
-                            FieldHandler.encryptField(fieldConverter.toCanonical(node, fc.getName(), serdeType, schemaCacheKey), FieldConfigUtils.buildPayloadMetaData(fc, config), kryptonite, serdeType));
+                            FieldHandler.encryptField(fieldConverter.toCanonical(node, fc.getName(), serdeType, schemaCacheKey), FieldConfigUtils.buildPayloadMetaData(fc, config, resolvedKeyId), kryptonite, serdeType));
                 }
             }
         }
@@ -133,17 +135,24 @@ abstract class AbstractJsonRecordProcessor implements RecordValueProcessor {
             if (fieldValue instanceof JsonNode fvNode && fvNode.isNull()) continue; // null value — not a ciphertext
             FieldConfig.FieldMode mode = fc.getFieldMode().orElse(FieldConfig.DEFAULT_MODE);
             if (mode == FieldConfig.FieldMode.ELEMENT && fieldValue instanceof ArrayNode arr) {
-                accessor.setField(fc.getName(), decryptArrayElements(arr, fc));
+                String resolvedKeyId = FieldConfigUtils.isFpe(fc, config)
+                        ? DynamicKeyIdResolver.resolve(fc, config, accessor)
+                        : null;
+                accessor.setField(fc.getName(), decryptArrayElements(arr, fc, resolvedKeyId));
             } else if (mode == FieldConfig.FieldMode.ELEMENT && fieldValue instanceof ObjectNode obj) {
-                accessor.setField(fc.getName(), decryptObjectValues(obj, fc));
+                String resolvedKeyId = FieldConfigUtils.isFpe(fc, config)
+                        ? DynamicKeyIdResolver.resolve(fc, config, accessor)
+                        : null;
+                accessor.setField(fc.getName(), decryptObjectValues(obj, fc, resolvedKeyId));
             } else {
                 if (!(fieldValue instanceof JsonNode leafNode) || !leafNode.isTextual()) {
                     LOG.warn("Decryption skipping field '{}': value is not a textual node — possibly pre-existing unencrypted data", fc.getName());
                     continue;
                 }
                 if (FieldConfigUtils.isFpe(fc, config)) {
+                    String resolvedKeyId = DynamicKeyIdResolver.resolve(fc, config, accessor);
                     byte[] ciphertext = leafNode.asText().getBytes(StandardCharsets.UTF_8);
-                    byte[] plaintext = kryptonite.decipherFieldFPE(ciphertext, FieldConfigUtils.buildFieldMetaData(fc, config));
+                    byte[] plaintext = kryptonite.decipherFieldFPE(ciphertext, FieldConfigUtils.buildFieldMetaData(fc, config, resolvedKeyId));
                     accessor.setField(fc.getName(), new String(plaintext, StandardCharsets.UTF_8));
                 } else {
                     accessor.setField(fc.getName(),
@@ -154,14 +163,10 @@ abstract class AbstractJsonRecordProcessor implements RecordValueProcessor {
         return accessor.serialize();
     }
 
-    private ArrayNode encryptArrayElements(ArrayNode source, FieldConfig fc) {
-        return encryptArrayElements(source, fc, null);
-    }
-
-    protected ArrayNode encryptArrayElements(ArrayNode source, FieldConfig fc, String schemaCacheKey) {
+    protected ArrayNode encryptArrayElements(ArrayNode source, FieldConfig fc, String schemaCacheKey, String resolvedKeyId) {
         ArrayNode result = MAPPER.createArrayNode();
         if (FieldConfigUtils.isFpe(fc, config)) {
-            FieldMetaData fmd = FieldConfigUtils.buildFieldMetaData(fc, config);
+            FieldMetaData fmd = FieldConfigUtils.buildFieldMetaData(fc, config, resolvedKeyId);
             for (JsonNode element : source) {
                 if (!element.isTextual()) throw new IllegalStateException(
                         "FPE encryption requires string elements in field '" + fc.getName()
@@ -172,20 +177,16 @@ abstract class AbstractJsonRecordProcessor implements RecordValueProcessor {
             }
         } else {
             for (JsonNode element : source) {
-                result.add(FieldHandler.encryptField(fieldConverter.toCanonical(element, fc.getName(), serdeType, schemaCacheKey), FieldConfigUtils.buildPayloadMetaData(fc, config), kryptonite, serdeType));
+                result.add(FieldHandler.encryptField(fieldConverter.toCanonical(element, fc.getName(), serdeType, schemaCacheKey), FieldConfigUtils.buildPayloadMetaData(fc, config, resolvedKeyId), kryptonite, serdeType));
             }
         }
         return result;
     }
 
-    private ObjectNode encryptObjectValues(ObjectNode source, FieldConfig fc) {
-        return encryptObjectValues(source, fc, null);
-    }
-
-    protected ObjectNode encryptObjectValues(ObjectNode source, FieldConfig fc, String schemaCacheKey) {
+    protected ObjectNode encryptObjectValues(ObjectNode source, FieldConfig fc, String schemaCacheKey, String resolvedKeyId) {
         ObjectNode result = MAPPER.createObjectNode();
         if (FieldConfigUtils.isFpe(fc, config)) {
-            FieldMetaData fmd = FieldConfigUtils.buildFieldMetaData(fc, config);
+            FieldMetaData fmd = FieldConfigUtils.buildFieldMetaData(fc, config, resolvedKeyId);
             source.properties().forEach(entry -> {
                 JsonNode value = entry.getValue();
                 if (!value.isTextual()) throw new IllegalStateException(
@@ -198,16 +199,16 @@ abstract class AbstractJsonRecordProcessor implements RecordValueProcessor {
         } else {
             source.properties().forEach(entry ->
                 result.put(entry.getKey(),
-                        FieldHandler.encryptField(fieldConverter.toCanonical(entry.getValue(), fc.getName(), serdeType, schemaCacheKey), FieldConfigUtils.buildPayloadMetaData(fc, config), kryptonite, serdeType))
+                        FieldHandler.encryptField(fieldConverter.toCanonical(entry.getValue(), fc.getName(), serdeType, schemaCacheKey), FieldConfigUtils.buildPayloadMetaData(fc, config, resolvedKeyId), kryptonite, serdeType))
             );
         }
         return result;
     }
 
-    private ArrayNode decryptArrayElements(ArrayNode source, FieldConfig fc) {
+    private ArrayNode decryptArrayElements(ArrayNode source, FieldConfig fc, String resolvedKeyId) {
         ArrayNode result = MAPPER.createArrayNode();
         if (FieldConfigUtils.isFpe(fc, config)) {
-            FieldMetaData fmd = FieldConfigUtils.buildFieldMetaData(fc, config);
+            FieldMetaData fmd = FieldConfigUtils.buildFieldMetaData(fc, config, resolvedKeyId);
             for (JsonNode element : source) {
                 if (element.isNull()) {
                     result.addNull();
@@ -239,10 +240,10 @@ abstract class AbstractJsonRecordProcessor implements RecordValueProcessor {
         return result;
     }
 
-    private ObjectNode decryptObjectValues(ObjectNode source, FieldConfig fc) {
+    private ObjectNode decryptObjectValues(ObjectNode source, FieldConfig fc, String resolvedKeyId) {
         ObjectNode result = MAPPER.createObjectNode();
         if (FieldConfigUtils.isFpe(fc, config)) {
-            FieldMetaData fmd = FieldConfigUtils.buildFieldMetaData(fc, config);
+            FieldMetaData fmd = FieldConfigUtils.buildFieldMetaData(fc, config, resolvedKeyId);
             source.properties().forEach(entry -> {
                 JsonNode value = entry.getValue();
                 if (value.isNull()) {

--- a/kroxylicious-filter-kryptonite/src/main/java/com/github/hpgrahsl/kroxylicious/filters/kryptonite/processor/AvroSchemaRegistryRecordProcessor.java
+++ b/kroxylicious-filter-kryptonite/src/main/java/com/github/hpgrahsl/kroxylicious/filters/kryptonite/processor/AvroSchemaRegistryRecordProcessor.java
@@ -66,6 +66,7 @@ public class AvroSchemaRegistryRecordProcessor implements RecordValueProcessor {
         for (FieldConfig fc : fieldConfigs) {
             Object fieldValue = accessor.getField(fc.getName());
             FieldConfig.FieldMode mode = fc.getFieldMode().orElse(FieldConfig.DEFAULT_MODE);
+            String resolvedKeyId = DynamicKeyIdResolver.resolve(fc, config, accessor);
             if (fieldValue == null && mode == FieldConfig.FieldMode.ELEMENT) {
                 LOG.warn("ELEMENT mode field '{}' in topic '{}' has a null container value — skipping " +
                         "(null container cannot be encrypted element-by-element; use OBJECT mode to encrypt null fields)",
@@ -75,24 +76,24 @@ public class AvroSchemaRegistryRecordProcessor implements RecordValueProcessor {
 
             if (mode == FieldConfig.FieldMode.ELEMENT && fieldValue instanceof List<?> list) {
                 Schema elementSchema = resolveFieldSchema(schema, fc.getName()).getElementType();
-                accessor.setField(fc.getName(), encryptListElements(list, fc, elementSchema));
+                accessor.setField(fc.getName(), encryptListElements(list, fc, elementSchema, resolvedKeyId));
             } else if (mode == FieldConfig.FieldMode.ELEMENT && fieldValue instanceof Map<?, ?> map) {
                 Schema valueSchema = resolveFieldSchema(schema, fc.getName()).getValueType();
-                accessor.setField(fc.getName(), encryptMapValues(map, fc, valueSchema));
+                accessor.setField(fc.getName(), encryptMapValues(map, fc, valueSchema, resolvedKeyId));
             } else if (mode == FieldConfig.FieldMode.ELEMENT && fieldValue instanceof GenericRecord record) {
-                accessor.setField(fc.getName(), encryptRecordFieldValues(record, fc));
+                accessor.setField(fc.getName(), encryptRecordFieldValues(record, fc, resolvedKeyId));
             } else {
                 if (FieldConfigUtils.isFpe(fc, config)) {
                     if (!(fieldValue instanceof CharSequence cs)) throw new IllegalStateException(
                             "FPE encryption requires a string value for field '" + fc.getName()
                             + "' but got type " + fieldValue.getClass().getSimpleName() + " — FPE cannot encrypt non-string types");
                     byte[] ciphertext = kryptonite.cipherFieldFPE(
-                            cs.toString().getBytes(StandardCharsets.UTF_8), FieldConfigUtils.buildFieldMetaData(fc, config));
+                            cs.toString().getBytes(StandardCharsets.UTF_8), FieldConfigUtils.buildFieldMetaData(fc, config, resolvedKeyId));
                     accessor.setField(fc.getName(), new String(ciphertext, StandardCharsets.UTF_8));
                 } else {
                     Schema fieldSchema = resolveFieldSchema(schema, fc.getName());
                     accessor.setField(fc.getName(),
-                            FieldHandler.encryptField(fieldConverter.toCanonical(fieldValue, fieldSchema, serdeType), FieldConfigUtils.buildPayloadMetaData(fc, config), kryptonite, serdeType));
+                            FieldHandler.encryptField(fieldConverter.toCanonical(fieldValue, fieldSchema, serdeType), FieldConfigUtils.buildPayloadMetaData(fc, config, resolvedKeyId), kryptonite, serdeType));
                 }
             }
         }
@@ -127,9 +128,15 @@ public class AvroSchemaRegistryRecordProcessor implements RecordValueProcessor {
             FieldConfig.FieldMode mode = fc.getFieldMode().orElse(FieldConfig.DEFAULT_MODE);
 
             if (mode == FieldConfig.FieldMode.ELEMENT && fieldValue instanceof List<?> list) {
-                accessor.setField(fc.getName(), decryptListElements(list, fc));
+                String resolvedKeyId = FieldConfigUtils.isFpe(fc, config)
+                        ? DynamicKeyIdResolver.resolve(fc, config, accessor)
+                        : null;
+                accessor.setField(fc.getName(), decryptListElements(list, fc, resolvedKeyId));
             } else if (mode == FieldConfig.FieldMode.ELEMENT && fieldValue instanceof Map<?, ?> map) {
-                accessor.setField(fc.getName(), decryptMapValues(map, fc));
+                String resolvedKeyId = FieldConfigUtils.isFpe(fc, config)
+                        ? DynamicKeyIdResolver.resolve(fc, config, accessor)
+                        : null;
+                accessor.setField(fc.getName(), decryptMapValues(map, fc, resolvedKeyId));
             } else if (mode == FieldConfig.FieldMode.ELEMENT && fieldValue instanceof GenericRecord record) {
                 accessor.setField(fc.getName(), decryptRecordFieldValues(record, fc));
             } else {
@@ -139,8 +146,9 @@ public class AvroSchemaRegistryRecordProcessor implements RecordValueProcessor {
                     continue;
                 }
                 if (FieldConfigUtils.isFpe(fc, config)) {
+                    String resolvedKeyId = DynamicKeyIdResolver.resolve(fc, config, accessor);
                     byte[] plaintext = kryptonite.decipherFieldFPE(
-                            cs.toString().getBytes(StandardCharsets.UTF_8), FieldConfigUtils.buildFieldMetaData(fc, config));
+                            cs.toString().getBytes(StandardCharsets.UTF_8), FieldConfigUtils.buildFieldMetaData(fc, config, resolvedKeyId));
                     accessor.setField(fc.getName(), new String(plaintext, StandardCharsets.UTF_8));
                 } else {
                     accessor.setField(fc.getName(),
@@ -162,10 +170,10 @@ public class AvroSchemaRegistryRecordProcessor implements RecordValueProcessor {
 
     // ---- ELEMENT mode helpers ----
 
-    private List<Object> encryptListElements(List<?> source, FieldConfig fc, Schema elementSchema) {
+    private List<Object> encryptListElements(List<?> source, FieldConfig fc, Schema elementSchema, String resolvedKeyId) {
         List<Object> result = new ArrayList<>();
         if (FieldConfigUtils.isFpe(fc, config)) {
-            FieldMetaData fmd = FieldConfigUtils.buildFieldMetaData(fc, config);
+            FieldMetaData fmd = FieldConfigUtils.buildFieldMetaData(fc, config, resolvedKeyId);
             for (Object element : source) {
                 if (!(element instanceof CharSequence cs)) throw new IllegalStateException(
                         "FPE encryption requires string elements in field '" + fc.getName()
@@ -176,16 +184,16 @@ public class AvroSchemaRegistryRecordProcessor implements RecordValueProcessor {
             }
         } else {
             for (Object element : source) {
-                result.add(FieldHandler.encryptField(fieldConverter.toCanonical(element, elementSchema, serdeType), FieldConfigUtils.buildPayloadMetaData(fc, config), kryptonite, serdeType));
+                result.add(FieldHandler.encryptField(fieldConverter.toCanonical(element, elementSchema, serdeType), FieldConfigUtils.buildPayloadMetaData(fc, config, resolvedKeyId), kryptonite, serdeType));
             }
         }
         return result;
     }
 
-    private Map<Object, Object> encryptMapValues(Map<?, ?> source, FieldConfig fc, Schema valueSchema) {
+    private Map<Object, Object> encryptMapValues(Map<?, ?> source, FieldConfig fc, Schema valueSchema, String resolvedKeyId) {
         Map<Object, Object> result = new java.util.LinkedHashMap<>();
         if (FieldConfigUtils.isFpe(fc, config)) {
-            FieldMetaData fmd = FieldConfigUtils.buildFieldMetaData(fc, config);
+            FieldMetaData fmd = FieldConfigUtils.buildFieldMetaData(fc, config, resolvedKeyId);
             source.forEach((k, v) -> {
                 if (!(v instanceof CharSequence cs)) throw new IllegalStateException(
                         "FPE encryption requires string values in field '" + fc.getName()
@@ -196,16 +204,16 @@ public class AvroSchemaRegistryRecordProcessor implements RecordValueProcessor {
             });
         } else {
             source.forEach((k, v) -> {
-                result.put(k, FieldHandler.encryptField(fieldConverter.toCanonical(v, valueSchema, serdeType), FieldConfigUtils.buildPayloadMetaData(fc, config), kryptonite, serdeType));
+                result.put(k, FieldHandler.encryptField(fieldConverter.toCanonical(v, valueSchema, serdeType), FieldConfigUtils.buildPayloadMetaData(fc, config, resolvedKeyId), kryptonite, serdeType));
             });
         }
         return result;
     }
 
-    private List<Object> decryptListElements(List<?> source, FieldConfig fc) {
+    private List<Object> decryptListElements(List<?> source, FieldConfig fc, String resolvedKeyId) {
         List<Object> result = new ArrayList<>();
         if (FieldConfigUtils.isFpe(fc, config)) {
-            FieldMetaData fmd = FieldConfigUtils.buildFieldMetaData(fc, config);
+            FieldMetaData fmd = FieldConfigUtils.buildFieldMetaData(fc, config, resolvedKeyId);
             for (Object element : source) {
                 if (element == null) {
                     LOG.warn("Decryption skipping null element in field '{}' — possibly pre-existing unencrypted data", fc.getName());
@@ -241,10 +249,10 @@ public class AvroSchemaRegistryRecordProcessor implements RecordValueProcessor {
         return result;
     }
 
-    private Map<Object, Object> decryptMapValues(Map<?, ?> source, FieldConfig fc) {
+    private Map<Object, Object> decryptMapValues(Map<?, ?> source, FieldConfig fc, String resolvedKeyId) {
         Map<Object, Object> result = new java.util.LinkedHashMap<>();
         if (FieldConfigUtils.isFpe(fc, config)) {
-            FieldMetaData fmd = FieldConfigUtils.buildFieldMetaData(fc, config);
+            FieldMetaData fmd = FieldConfigUtils.buildFieldMetaData(fc, config, resolvedKeyId);
             source.forEach((k, v) -> {
                 if (v instanceof CharSequence cs) {
                     byte[] plaintext = kryptonite.decipherFieldFPE(
@@ -270,11 +278,11 @@ public class AvroSchemaRegistryRecordProcessor implements RecordValueProcessor {
         return result;
     }
 
-    private GenericRecord encryptRecordFieldValues(GenericRecord source, FieldConfig fc) {
+    private GenericRecord encryptRecordFieldValues(GenericRecord source, FieldConfig fc, String resolvedKeyId) {
         GenericData.Record result = new GenericData.Record(source.getSchema());
         for (Schema.Field f : source.getSchema().getFields()) {
             Object value = source.get(f.name());
-            result.put(f.name(), FieldHandler.encryptField(fieldConverter.toCanonical(value, f.schema(), serdeType), FieldConfigUtils.buildPayloadMetaData(fc, config), kryptonite, serdeType));
+            result.put(f.name(), FieldHandler.encryptField(fieldConverter.toCanonical(value, f.schema(), serdeType), FieldConfigUtils.buildPayloadMetaData(fc, config, resolvedKeyId), kryptonite, serdeType));
         }
         return result;
     }

--- a/kroxylicious-filter-kryptonite/src/main/java/com/github/hpgrahsl/kroxylicious/filters/kryptonite/processor/DynamicKeyIdResolver.java
+++ b/kroxylicious-filter-kryptonite/src/main/java/com/github/hpgrahsl/kroxylicious/filters/kryptonite/processor/DynamicKeyIdResolver.java
@@ -1,0 +1,77 @@
+package com.github.hpgrahsl.kroxylicious.filters.kryptonite.processor;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.hpgrahsl.kryptonite.Kryptonite;
+import com.github.hpgrahsl.kroxylicious.filters.kryptonite.config.FieldConfig;
+import com.github.hpgrahsl.kroxylicious.filters.kryptonite.config.KryptoniteFilterConfig;
+import com.github.hpgrahsl.kroxylicious.filters.kryptonite.processor.accessor.StructuredRecordAccessor;
+
+/**
+ * Resolves the effective key identifier for a field against the current record.
+ *
+ * <p>If the configured key id starts with {@code dynamic_key_id_prefix}, the remaining suffix is
+ * interpreted as a field path and resolved through the provided {@link StructuredRecordAccessor}.
+ * Otherwise the configured key id is returned unchanged.
+ */
+final class DynamicKeyIdResolver {
+
+    private DynamicKeyIdResolver() {}
+
+    static String resolve(FieldConfig fc, KryptoniteFilterConfig config, StructuredRecordAccessor accessor) {
+        String configuredKeyId = configuredKeyId(fc, config);
+        String prefix = config.getDynamicKeyIdPrefix();
+        if (!configuredKeyId.startsWith(prefix)) {
+            return configuredKeyId;
+        }
+
+        String fieldPath = configuredKeyId.substring(prefix.length());
+        if (fieldPath.isBlank()) {
+            throw new IllegalStateException("Dynamic key identifier '" + configuredKeyId
+                    + "' has no field path after prefix '" + prefix + "'");
+        }
+
+        Object extracted = accessor.getField(fieldPath);
+        if (extracted == null) {
+            throw new IllegalStateException("Dynamic key identifier resolution failed for expression '"
+                    + configuredKeyId + "': field path '" + fieldPath + "' was not found or resolved to null");
+        }
+
+        if (extracted instanceof JsonNode node) {
+            if (!node.isTextual()) {
+                throw new IllegalStateException("Dynamic key identifier resolution failed for expression '"
+                        + configuredKeyId + "': field path '" + fieldPath + "' resolved to JSON type "
+                        + node.getNodeType() + " but a textual value is required");
+            }
+            return requireNonBlank(configuredKeyId, fieldPath, node.asText());
+        }
+
+        if (extracted instanceof CharSequence cs) {
+            return requireNonBlank(configuredKeyId, fieldPath, cs.toString());
+        }
+
+        throw new IllegalStateException("Dynamic key identifier resolution failed for expression '"
+                + configuredKeyId + "': field path '" + fieldPath + "' resolved to type "
+                + extracted.getClass().getSimpleName() + " but a string value is required");
+    }
+
+    private static String configuredKeyId(FieldConfig fc, KryptoniteFilterConfig config) {
+        if (fc.getKeyId().isPresent()) {
+            return fc.getKeyId().get();
+        }
+        String algorithm = fc.getAlgorithm().orElse(config.getCipherAlgorithm());
+        var cipherSpec = Kryptonite.CipherSpec.fromName(algorithm.toUpperCase());
+        if (cipherSpec instanceof Kryptonite.KmsEnvelopeCipherSpec) {
+            return config.getEnvelopeKekIdentifier();
+        }
+        return config.getCipherDataKeyIdentifier();
+    }
+
+    private static String requireNonBlank(String configuredKeyId, String fieldPath, String resolvedKeyId) {
+        if (resolvedKeyId == null || resolvedKeyId.isBlank()) {
+            throw new IllegalStateException("Dynamic key identifier resolution failed for expression '"
+                    + configuredKeyId + "': field path '" + fieldPath
+                    + "' resolved to a blank string but a non-blank key id is required");
+        }
+        return resolvedKeyId;
+    }
+}

--- a/kroxylicious-filter-kryptonite/src/main/java/com/github/hpgrahsl/kroxylicious/filters/kryptonite/processor/FieldConfigUtils.java
+++ b/kroxylicious-filter-kryptonite/src/main/java/com/github/hpgrahsl/kroxylicious/filters/kryptonite/processor/FieldConfigUtils.java
@@ -23,9 +23,8 @@ final class FieldConfigUtils {
         return Kryptonite.CipherSpec.fromName(algorithm.toUpperCase()).isCipherFPE();
     }
 
-    static FieldMetaData buildFieldMetaData(FieldConfig fc, KryptoniteFilterConfig config) {
+    static FieldMetaData buildFieldMetaData(FieldConfig fc, KryptoniteFilterConfig config, String keyId) {
         String algorithm = fc.getAlgorithm().orElse(config.getCipherAlgorithm());
-        String keyId = fc.getKeyId().orElse(config.getCipherDataKeyIdentifier());
         String fpeTweak = fc.getFpeTweak().orElse(KryptoniteSettings.CIPHER_FPE_TWEAK_DEFAULT);
         String fpeAlphabet = determineAlphabet(fc);
         String encoding = fc.getEncoding().orElse(KryptoniteSettings.CIPHER_TEXT_ENCODING_DEFAULT);
@@ -39,10 +38,9 @@ final class FieldConfigUtils {
                 .build();
     }
 
-    static PayloadMetaData buildPayloadMetaData(FieldConfig fc, KryptoniteFilterConfig config) {
+    static PayloadMetaData buildPayloadMetaData(FieldConfig fc, KryptoniteFilterConfig config, String keyId) {
         String algorithm = fc.getAlgorithm().orElse(config.getCipherAlgorithm());
         String algorithmId = Kryptonite.CIPHERSPEC_ID_LUT.get(Kryptonite.CipherSpec.fromName(algorithm));
-        String keyId = fc.getKeyId().orElse(config.getCipherDataKeyIdentifier());
         return new PayloadMetaData(Kryptonite.KRYPTONITE_VERSION, algorithmId, keyId);
     }
 

--- a/kroxylicious-filter-kryptonite/src/main/java/com/github/hpgrahsl/kroxylicious/filters/kryptonite/processor/JsonSchemaRegistryRecordProcessor.java
+++ b/kroxylicious-filter-kryptonite/src/main/java/com/github/hpgrahsl/kroxylicious/filters/kryptonite/processor/JsonSchemaRegistryRecordProcessor.java
@@ -121,6 +121,7 @@ public class JsonSchemaRegistryRecordProcessor extends AbstractJsonRecordProcess
             if (fieldValue == null) continue;
             JsonNode node = (JsonNode) fieldValue;
             FieldConfig.FieldMode mode = fc.getFieldMode().orElse(FieldConfig.DEFAULT_MODE);
+            String resolvedKeyId = DynamicKeyIdResolver.resolve(fc, config, accessor);
 
             if (mode == FieldConfig.FieldMode.ELEMENT && node.isNull()) {
                 LOG.warn("ELEMENT mode: field '{}' is null — skipping (cannot iterate null container)", fc.getName());
@@ -129,10 +130,10 @@ public class JsonSchemaRegistryRecordProcessor extends AbstractJsonRecordProcess
             if (mode == FieldConfig.FieldMode.ELEMENT && node.isArray()) {
                 // ELEMENT mode: fall back to value-derived schema with topic-scoped caching
                 String schemaCacheKey = topicName + "." + fc.getName();
-                accessor.setField(fc.getName(), encryptArrayElements((ArrayNode) node, fc, schemaCacheKey));
+                accessor.setField(fc.getName(), encryptArrayElements((ArrayNode) node, fc, schemaCacheKey, resolvedKeyId));
             } else if (mode == FieldConfig.FieldMode.ELEMENT && node.isObject()) {
                 String schemaCacheKey = topicName + "." + fc.getName();
-                accessor.setField(fc.getName(), encryptObjectValues((ObjectNode) node, fc, schemaCacheKey));
+                accessor.setField(fc.getName(), encryptObjectValues((ObjectNode) node, fc, schemaCacheKey, resolvedKeyId));
             } else {
                 // OBJECT mode
                 if (FieldConfigUtils.isFpe(fc, config)) {
@@ -140,14 +141,14 @@ public class JsonSchemaRegistryRecordProcessor extends AbstractJsonRecordProcess
                             "FPE encryption requires a string value for field '" + fc.getName()
                             + "' but got JSON type " + node.getNodeType() + " — FPE cannot encrypt non-string types");
                     byte[] plaintext = node.asText().getBytes(StandardCharsets.UTF_8);
-                    byte[] ciphertext = kryptonite.cipherFieldFPE(plaintext, FieldConfigUtils.buildFieldMetaData(fc, config));
+                    byte[] ciphertext = kryptonite.cipherFieldFPE(plaintext, FieldConfigUtils.buildFieldMetaData(fc, config, resolvedKeyId));
                     accessor.setField(fc.getName(), new String(ciphertext, StandardCharsets.UTF_8));
                 } else {
                     Schema avroSchema = resolveFieldAvroSchema(schemaId, fc.getName());
                     accessor.setField(fc.getName(),
                             FieldHandler.encryptField(
                                     fieldConverter.toCanonical(node, fc.getName(), serdeType, avroSchema),
-                                    FieldConfigUtils.buildPayloadMetaData(fc, config), kryptonite, serdeType));
+                                    FieldConfigUtils.buildPayloadMetaData(fc, config, resolvedKeyId), kryptonite, serdeType));
                 }
             }
         }

--- a/kroxylicious-filter-kryptonite/src/test/java/com/github/hpgrahsl/kroxylicious/filters/kryptonite/processor/DynamicKeyIdResolverTest.java
+++ b/kroxylicious-filter-kryptonite/src/test/java/com/github/hpgrahsl/kroxylicious/filters/kryptonite/processor/DynamicKeyIdResolverTest.java
@@ -1,0 +1,338 @@
+package com.github.hpgrahsl.kroxylicious.filters.kryptonite.processor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.hpgrahsl.kroxylicious.filters.kryptonite.config.FieldConfig;
+import com.github.hpgrahsl.kroxylicious.filters.kryptonite.config.KryptoniteFilterConfig;
+import com.github.hpgrahsl.kroxylicious.filters.kryptonite.processor.accessor.AvroGenericRecordAccessor;
+import com.github.hpgrahsl.kroxylicious.filters.kryptonite.processor.accessor.JsonObjectNodeAccessor;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.util.Utf8;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("DynamicKeyIdResolver")
+class DynamicKeyIdResolverTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static KryptoniteFilterConfig config(Map<String, Object> overrides) {
+        var base = new HashMap<String, Object>();
+        base.put("key_source", "CONFIG");
+        base.put("cipher_algorithm", "TINK/AES_GCM");
+        base.put("cipher_data_key_identifier", "default-key");
+        base.put("dynamic_key_id_prefix", "__#");
+        base.putAll(overrides);
+        return MAPPER.convertValue(base, KryptoniteFilterConfig.class);
+    }
+
+    @Nested
+    @DisplayName("JsonObjectNodeAccessor")
+    class JsonAccessor {
+
+        @Test
+        @DisplayName("returns static field-level key id unchanged")
+        void returnsStaticFieldLevelKeyId() {
+            var cfg = config(Map.of("cipher_data_key_identifier", "default-key"));
+            var fc = FieldConfig.builder().name("age").keyId("explicit-key").build();
+            var accessor = JsonObjectNodeAccessor.from("""
+                    {
+                      "customer": {
+                        "country": "de"
+                      },
+                      "age": 30
+                    }
+                    """.getBytes());
+
+            assertThat(DynamicKeyIdResolver.resolve(fc, cfg, accessor)).isEqualTo("explicit-key");
+        }
+
+        @Test
+        @DisplayName("resolves dynamic default key id from nested field path")
+        void resolvesDynamicDefaultKeyId() {
+            var cfg = config(Map.of("cipher_data_key_identifier", "__#customer.country"));
+            var fc = FieldConfig.builder().name("age").build();
+            var accessor = JsonObjectNodeAccessor.from("""
+                    {
+                      "customer": {
+                        "country": "de"
+                      },
+                      "age": 30
+                    }
+                    """.getBytes());
+
+            assertThat(DynamicKeyIdResolver.resolve(fc, cfg, accessor)).isEqualTo("de");
+        }
+
+        @Test
+        @DisplayName("resolves dynamic field-level key id from nested field path")
+        void resolvesDynamicFieldLevelKeyId() {
+            var cfg = config(Map.of());
+            var fc = FieldConfig.builder().name("age").keyId("__#customer.country").build();
+            var accessor = JsonObjectNodeAccessor.from("""
+                    {
+                      "customer": {
+                        "country": "de"
+                      },
+                      "age": 30
+                    }
+                    """.getBytes());
+
+            assertThat(DynamicKeyIdResolver.resolve(fc, cfg, accessor)).isEqualTo("de");
+        }
+
+        @Test
+        @DisplayName("resolves dynamic KMS envelope fallback from envelope_kek_identifier")
+        void resolvesDynamicKmsEnvelopeFallbackFromEnvelopeKekIdentifier() {
+            var cfg = config(Map.of(
+                    "cipher_algorithm", "TINK/AES_GCM_ENVELOPE_KMS",
+                    "cipher_data_key_identifier", "data-key",
+                    "envelope_kek_identifier", "__#customer.country"));
+            var fc = FieldConfig.builder().name("age").build();
+            var accessor = JsonObjectNodeAccessor.from("""
+                    {
+                      "customer": {
+                        "country": "de"
+                      },
+                      "age": 30
+                    }
+                    """.getBytes());
+
+            assertThat(DynamicKeyIdResolver.resolve(fc, cfg, accessor)).isEqualTo("de");
+        }
+
+        @Test
+        @DisplayName("prefers field-level keyId over envelope_kek_identifier for KMS envelope")
+        void prefersFieldLevelKeyIdOverEnvelopeKekIdentifierForKmsEnvelope() {
+            var cfg = config(Map.of(
+                    "cipher_algorithm", "TINK/AES_GCM_ENVELOPE_KMS",
+                    "envelope_kek_identifier", "__#customer.country"));
+            var fc = FieldConfig.builder().name("age").keyId("__#customer.region").build();
+            var accessor = JsonObjectNodeAccessor.from("""
+                    {
+                      "customer": {
+                        "country": "de",
+                        "region": "eu"
+                      },
+                      "age": 30
+                    }
+                    """.getBytes());
+
+            assertThat(DynamicKeyIdResolver.resolve(fc, cfg, accessor)).isEqualTo("eu");
+        }
+
+        @Test
+        @DisplayName("throws when dynamic field path is missing")
+        void throwsWhenDynamicFieldPathMissing() {
+            var cfg = config(Map.of("cipher_data_key_identifier", "__#customer.country"));
+            var fc = FieldConfig.builder().name("age").build();
+            var accessor = JsonObjectNodeAccessor.from("""
+                    {
+                      "age": 30
+                    }
+                    """.getBytes());
+
+            assertThatThrownBy(() -> DynamicKeyIdResolver.resolve(fc, cfg, accessor))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("customer.country");
+        }
+
+        @Test
+        @DisplayName("throws when resolved value is not textual")
+        void throwsWhenResolvedValueIsNotTextual() {
+            var cfg = config(Map.of("cipher_data_key_identifier", "__#customer.id"));
+            var fc = FieldConfig.builder().name("age").build();
+            var accessor = JsonObjectNodeAccessor.from("""
+                    {
+                      "customer": {
+                        "id": 123
+                      },
+                      "age": 30
+                    }
+                    """.getBytes());
+
+            assertThatThrownBy(() -> DynamicKeyIdResolver.resolve(fc, cfg, accessor))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("textual");
+        }
+
+        @Test
+        @DisplayName("throws when resolved value is blank")
+        void throwsWhenResolvedValueIsBlank() {
+            var cfg = config(Map.of("cipher_data_key_identifier", "__#customer.country"));
+            var fc = FieldConfig.builder().name("age").build();
+            var accessor = JsonObjectNodeAccessor.from("""
+                    {
+                      "customer": {
+                        "country": "   "
+                      },
+                      "age": 30
+                    }
+                    """.getBytes());
+
+            assertThatThrownBy(() -> DynamicKeyIdResolver.resolve(fc, cfg, accessor))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("blank string");
+        }
+
+        @Test
+        @DisplayName("throws when dynamic expression has no suffix after prefix")
+        void throwsWhenDynamicExpressionHasNoSuffix() {
+            var cfg = config(Map.of("cipher_data_key_identifier", "__#"));
+            var fc = FieldConfig.builder().name("age").build();
+            var accessor = JsonObjectNodeAccessor.from("""
+                    {
+                      "age": 30
+                    }
+                    """.getBytes());
+
+            assertThatThrownBy(() -> DynamicKeyIdResolver.resolve(fc, cfg, accessor))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("has no field path");
+        }
+    }
+
+    @Nested
+    @DisplayName("AvroGenericRecordAccessor")
+    class AvroAccessor {
+
+        private Schema customerSchema() {
+            return SchemaBuilder.record("Customer").namespace("test").fields()
+                    .name("country").type().stringType().noDefault()
+                    .name("region").type().stringType().noDefault()
+                    .name("id").type().intType().noDefault()
+                    .endRecord();
+        }
+
+        private Schema rootSchema() {
+            return SchemaBuilder.record("Order").namespace("test").fields()
+                    .name("customer").type(customerSchema()).noDefault()
+                    .name("age").type().intType().noDefault()
+                    .endRecord();
+        }
+
+        private AvroGenericRecordAccessor accessor(String country, String region, Integer id) {
+            Schema customerSchema = customerSchema();
+            Schema rootSchema = rootSchema();
+            GenericRecord customer = new GenericData.Record(customerSchema);
+            customer.put("country", country != null ? new Utf8(country) : null);
+            customer.put("region", region != null ? new Utf8(region) : null);
+            customer.put("id", id);
+            GenericRecord root = new GenericData.Record(rootSchema);
+            root.put("customer", customer);
+            root.put("age", 30);
+            return AvroGenericRecordAccessor.of(root, rootSchema);
+        }
+
+        private AvroGenericRecordAccessor accessorWithoutCustomer() {
+            Schema rootSchema = rootSchema();
+            GenericRecord root = new GenericData.Record(rootSchema);
+            root.put("customer", null);
+            root.put("age", 30);
+            return AvroGenericRecordAccessor.of(root, rootSchema);
+        }
+
+        @Test
+        @DisplayName("returns static field-level key id unchanged")
+        void returnsStaticFieldLevelKeyId() {
+            var cfg = config(Map.of("cipher_data_key_identifier", "default-key"));
+            var fc = FieldConfig.builder().name("age").keyId("explicit-key").build();
+
+            assertThat(DynamicKeyIdResolver.resolve(fc, cfg, accessor("de", "eu", 123))).isEqualTo("explicit-key");
+        }
+
+        @Test
+        @DisplayName("resolves dynamic default key id from nested field path")
+        void resolvesDynamicDefaultKeyId() {
+            var cfg = config(Map.of("cipher_data_key_identifier", "__#customer.country"));
+            var fc = FieldConfig.builder().name("age").build();
+
+            assertThat(DynamicKeyIdResolver.resolve(fc, cfg, accessor("de", "eu", 123))).isEqualTo("de");
+        }
+
+        @Test
+        @DisplayName("resolves dynamic field-level key id from nested field path")
+        void resolvesDynamicFieldLevelKeyId() {
+            var cfg = config(Map.of());
+            var fc = FieldConfig.builder().name("age").keyId("__#customer.country").build();
+
+            assertThat(DynamicKeyIdResolver.resolve(fc, cfg, accessor("de", "eu", 123))).isEqualTo("de");
+        }
+
+        @Test
+        @DisplayName("resolves dynamic KMS envelope fallback from envelope_kek_identifier")
+        void resolvesDynamicKmsEnvelopeFallbackFromEnvelopeKekIdentifier() {
+            var cfg = config(Map.of(
+                    "cipher_algorithm", "TINK/AES_GCM_ENVELOPE_KMS",
+                    "cipher_data_key_identifier", "data-key",
+                    "envelope_kek_identifier", "__#customer.country"));
+            var fc = FieldConfig.builder().name("age").build();
+
+            assertThat(DynamicKeyIdResolver.resolve(fc, cfg, accessor("de", "eu", 123))).isEqualTo("de");
+        }
+
+        @Test
+        @DisplayName("prefers field-level keyId over envelope_kek_identifier for KMS envelope")
+        void prefersFieldLevelKeyIdOverEnvelopeKekIdentifierForKmsEnvelope() {
+            var cfg = config(Map.of(
+                    "cipher_algorithm", "TINK/AES_GCM_ENVELOPE_KMS",
+                    "envelope_kek_identifier", "__#customer.country"));
+            var fc = FieldConfig.builder().name("age").keyId("__#customer.region").build();
+
+            assertThat(DynamicKeyIdResolver.resolve(fc, cfg, accessor("de", "eu", 123))).isEqualTo("eu");
+        }
+
+        @Test
+        @DisplayName("throws when dynamic field path is missing")
+        void throwsWhenDynamicFieldPathMissing() {
+            var cfg = config(Map.of("cipher_data_key_identifier", "__#customer.country"));
+            var fc = FieldConfig.builder().name("age").build();
+
+            assertThatThrownBy(() -> DynamicKeyIdResolver.resolve(fc, cfg, accessorWithoutCustomer()))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("customer.country");
+        }
+
+        @Test
+        @DisplayName("throws when resolved value is not textual")
+        void throwsWhenResolvedValueIsNotTextual() {
+            var cfg = config(Map.of("cipher_data_key_identifier", "__#customer.id"));
+            var fc = FieldConfig.builder().name("age").build();
+
+            assertThatThrownBy(() -> DynamicKeyIdResolver.resolve(fc, cfg, accessor("de", "eu", 123)))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("string value is required");
+        }
+
+        @Test
+        @DisplayName("throws when resolved value is blank")
+        void throwsWhenResolvedValueIsBlank() {
+            var cfg = config(Map.of("cipher_data_key_identifier", "__#customer.country"));
+            var fc = FieldConfig.builder().name("age").build();
+
+            assertThatThrownBy(() -> DynamicKeyIdResolver.resolve(fc, cfg, accessor("   ", "eu", 123)))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("blank string");
+        }
+
+        @Test
+        @DisplayName("throws when dynamic expression has no suffix after prefix")
+        void throwsWhenDynamicExpressionHasNoSuffix() {
+            var cfg = config(Map.of("cipher_data_key_identifier", "__#"));
+            var fc = FieldConfig.builder().name("age").build();
+
+            assertThatThrownBy(() -> DynamicKeyIdResolver.resolve(fc, cfg, accessor("de", "eu", 123)))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("has no field path");
+        }
+    }
+}

--- a/kroxylicious-filter-kryptonite/src/test/java/com/github/hpgrahsl/kroxylicious/filters/kryptonite/processor/PlainJsonRecordProcessorTest.java
+++ b/kroxylicious-filter-kryptonite/src/test/java/com/github/hpgrahsl/kroxylicious/filters/kryptonite/processor/PlainJsonRecordProcessorTest.java
@@ -7,11 +7,13 @@ import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.github.hpgrahsl.kryptonite.EncryptedField;
 import com.github.hpgrahsl.kryptonite.Kryptonite;
+import com.github.hpgrahsl.kryptonite.FieldMetaData;
 import com.github.hpgrahsl.kryptonite.PayloadMetaData;
 import com.github.hpgrahsl.kryptonite.serdes.kryo.KryoInstance;
 import com.github.hpgrahsl.kryptonite.serdes.kryo.KryoSerdeProcessor;
 import com.github.hpgrahsl.kryptonite.serdes.SerdeProcessor;
 import com.github.hpgrahsl.kroxylicious.filters.kryptonite.config.FieldConfig;
+import com.github.hpgrahsl.kroxylicious.filters.kryptonite.config.KryptoniteFilterConfig;
 import com.github.hpgrahsl.kroxylicious.filters.kryptonite.fixtures.TestFixtures;
 import com.github.hpgrahsl.kroxylicious.filters.kryptonite.processor.accessor.JsonObjectNodeAccessor;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,11 +24,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.ByteArrayOutputStream;
 import java.util.Base64;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -72,6 +76,80 @@ class PlainJsonRecordProcessorTest {
 
     private static byte[] serdeBytes(JsonNode node) {
         return JsonObjectNodeAccessor.nodeToBytes(node, SERDE);
+    }
+
+    @Test
+    @DisplayName("encryptFields resolves dynamic default key id from payload")
+    void encryptResolvesDynamicDefaultKeyIdFromPayload() {
+        var dynamicConfig = MAPPER.convertValue(Map.of(
+                "key_source", "CONFIG",
+                "cipher_algorithm", "TINK/AES_GCM",
+                "cipher_data_key_identifier", "__#customer.country",
+                "dynamic_key_id_prefix", "__#",
+                "serde_type", "KRYO"
+        ), KryptoniteFilterConfig.class);
+        processor = new PlainJsonRecordProcessor(kryptonite, dynamicConfig);
+        when(kryptonite.cipherFieldRaw(any(), any())).thenReturn(FAKE_EF.ciphertext());
+
+        byte[] input = """
+                {"customer":{"country":"de"},"age":30}""".getBytes();
+
+        processor.encryptFields(input, TOPIC,
+                Set.of(FieldConfig.builder().name("age").fieldMode(FieldConfig.FieldMode.OBJECT).build()));
+
+        ArgumentCaptor<PayloadMetaData> captor = ArgumentCaptor.forClass(PayloadMetaData.class);
+        verify(kryptonite).cipherFieldRaw(any(), captor.capture());
+        assertThat(captor.getValue().getKeyId()).isEqualTo("de");
+    }
+
+    @Test
+    @DisplayName("encryptFields resolves dynamic envelope_kek_identifier from payload for KMS envelope")
+    void encryptResolvesDynamicEnvelopeKekIdentifierFromPayloadForKmsEnvelope() {
+        var dynamicEnvelopeConfig = MAPPER.convertValue(Map.of(
+                "key_source", "NONE",
+                "cipher_algorithm", "TINK/AES_GCM_ENVELOPE_KMS",
+                "cipher_data_key_identifier", "data-key-ignored",
+                "envelope_kek_identifier", "__#customer.country",
+                "dynamic_key_id_prefix", "__#",
+                "serde_type", "KRYO",
+                "record_format", "JSON"
+        ), KryptoniteFilterConfig.class);
+        processor = new PlainJsonRecordProcessor(kryptonite, dynamicEnvelopeConfig);
+        when(kryptonite.cipherFieldRaw(any(), any())).thenReturn(FAKE_EF.ciphertext());
+
+        byte[] input = """
+                {"customer":{"country":"de"},"age":30}""".getBytes();
+
+        processor.encryptFields(input, TOPIC,
+                Set.of(FieldConfig.builder().name("age").fieldMode(FieldConfig.FieldMode.OBJECT).build()));
+
+        ArgumentCaptor<PayloadMetaData> captor = ArgumentCaptor.forClass(PayloadMetaData.class);
+        verify(kryptonite).cipherFieldRaw(any(), captor.capture());
+        assertThat(captor.getValue().getKeyId()).isEqualTo("de");
+    }
+
+    @Test
+    @DisplayName("decryptFields resolves dynamic default key id from payload for FPE")
+    void decryptResolvesDynamicDefaultKeyIdFromPayloadForFpe() {
+        var dynamicFpeConfig = MAPPER.convertValue(Map.of(
+                "key_source", "CONFIG",
+                "cipher_algorithm", "CUSTOM/MYSTO_FPE_FF3_1",
+                "cipher_data_key_identifier", "__#customer.country",
+                "dynamic_key_id_prefix", "__#"
+        ), KryptoniteFilterConfig.class);
+        processor = new PlainJsonRecordProcessor(kryptonite, dynamicFpeConfig);
+        when(kryptonite.decipherFieldFPE(any(), any())).thenReturn("4111111111111111".getBytes());
+
+        byte[] input = """
+                {"customer":{"country":"de"},"card":"ciphertext"}""".getBytes();
+
+        processor.decryptFields(input, TOPIC,
+                Set.of(FieldConfig.builder().name("card").fieldMode(FieldConfig.FieldMode.OBJECT).build()));
+
+        ArgumentCaptor<FieldMetaData> captor =
+                ArgumentCaptor.forClass(FieldMetaData.class);
+        verify(kryptonite).decipherFieldFPE(any(), captor.capture());
+        assertThat(captor.getValue().getKeyId()).isEqualTo("de");
     }
 
     // ---- encryptFields — OBJECT mode ----

--- a/kroxylicious-filter-kryptonite/src/test/java/com/github/hpgrahsl/kroxylicious/filters/kryptonite/processor/accessor/AvroGenericRecordAccessorTest.java
+++ b/kroxylicious-filter-kryptonite/src/test/java/com/github/hpgrahsl/kroxylicious/filters/kryptonite/processor/accessor/AvroGenericRecordAccessorTest.java
@@ -19,7 +19,6 @@ import static com.github.hpgrahsl.kroxylicious.filters.kryptonite.fixtures.TestF
 import static com.github.hpgrahsl.kroxylicious.filters.kryptonite.fixtures.TestFixtures.avroSerialize;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("AvroGenericRecordAccessor")
 class AvroGenericRecordAccessorTest {

--- a/kryptonite/src/main/java/com/github/hpgrahsl/kryptonite/Kryptonite.java
+++ b/kryptonite/src/main/java/com/github/hpgrahsl/kryptonite/Kryptonite.java
@@ -471,6 +471,7 @@ public class Kryptonite implements AutoCloseable {
 
   public static Kryptonite createFromConfig(Map<String,String> config) {
     try {
+      validateDynamicKeyIdPrefix(config);
       var keySource = KeySource.valueOf(config.get(KEY_SOURCE));
       LOG.log(INFO, "creating Kryptonite instance from config (keySource={0})", keySource);
       switch (keySource) {
@@ -491,6 +492,13 @@ public class Kryptonite implements AutoCloseable {
       throw e;
     } catch (Exception e) {
       throw new ConfigurationException(e.getMessage(), e);
+    }
+  }
+
+  private static void validateDynamicKeyIdPrefix(Map<String, String> config) {
+    var prefix = config.getOrDefault(DYNAMIC_KEY_ID_PREFIX, DYNAMIC_KEY_ID_PREFIX_DEFAULT);
+    if (prefix.isBlank()) {
+      throw new ConfigurationException("dynamic_key_id_prefix must not be blank");
     }
   }
 

--- a/kryptonite/src/main/java/com/github/hpgrahsl/kryptonite/config/KryptoniteSettings.java
+++ b/kryptonite/src/main/java/com/github/hpgrahsl/kryptonite/config/KryptoniteSettings.java
@@ -52,6 +52,7 @@ public class KryptoniteSettings {
   }
 
   public static final String FIELD_CONFIG = "field_config";
+  public static final String DYNAMIC_KEY_ID_PREFIX = "dynamic_key_id_prefix";
   public static final String PATH_DELIMITER = "path_delimiter";
   public static final String FIELD_MODE = "field_mode";
   public static final String CIPHER_ALGORITHM = "cipher_algorithm";
@@ -78,6 +79,7 @@ public class KryptoniteSettings {
   public static final String ENVELOPE_KEK_CONFIGS = "envelope_kek_configs";
   public static final String ENVELOPE_KEK_IDENTIFIER = "envelope_kek_identifier";
 
+  public static final String DYNAMIC_KEY_ID_PREFIX_DEFAULT = "__#";
   public static final String PATH_DELIMITER_DEFAULT = ".";
   public static final String FIELD_MODE_DEFAULT = "ELEMENT";
   public static final String CIPHER_ALGORITHM_DEFAULT = "TINK/AES_GCM";

--- a/kryptonite/src/test/java/com/github/hpgrahsl/kryptonite/KryptoniteTest.java
+++ b/kryptonite/src/test/java/com/github/hpgrahsl/kryptonite/KryptoniteTest.java
@@ -1,10 +1,15 @@
 package com.github.hpgrahsl.kryptonite;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -17,6 +22,21 @@ import com.github.hpgrahsl.kryptonite.keys.AbstractKeyVault;
 import com.github.hpgrahsl.kryptonite.keys.TinkKeyVault;
 
 public class KryptoniteTest {
+
+    @Test
+    @DisplayName("reject blank dynamic_key_id_prefix in config")
+    void rejectsBlankDynamicKeyIdPrefixInConfig() {
+        Map<String, String> config = new HashMap<>();
+        config.put(com.github.hpgrahsl.kryptonite.config.KryptoniteSettings.KEY_SOURCE, "CONFIG");
+        config.put(com.github.hpgrahsl.kryptonite.config.KryptoniteSettings.CIPHER_DATA_KEYS, TestFixtures.CIPHER_DATA_KEYS_CONFIG);
+        config.put(com.github.hpgrahsl.kryptonite.config.KryptoniteSettings.CIPHER_DATA_KEY_IDENTIFIER, "keyA");
+        config.put(com.github.hpgrahsl.kryptonite.config.KryptoniteSettings.DYNAMIC_KEY_ID_PREFIX, "   ");
+
+        var exception = assertThrows(com.github.hpgrahsl.kryptonite.config.ConfigurationException.class,
+                () -> Kryptonite.createFromConfig(config));
+        assertEquals("dynamic_key_id_prefix must not be blank", exception.getMessage());
+    }
+
 
     @ParameterizedTest
     @MethodSource("com.github.hpgrahsl.kryptonite.KryptoniteTest#provideValidInputParamsLocalKeyVaultNoKeyEncryption")


### PR DESCRIPTION
Add dynamic key identifier resolution support across the Kafka Connect SMT, Quarkus HTTP service, and Kroxylicious filter.

 Changes

 - support dynamic key ids via dynamic_key_id_prefix
 - resolve dynamic identifiers from record/payload field paths at runtime
 - support dynamic resolution for:
     - field-level keyId
     - default cipher_data_key_identifier
     - envelope_kek_identifier for TINK/AES_GCM_ENVELOPE_KMS
 - add/fix runtime handling in:
     - Connect SMT
     - Quarkus HTTP
     - Kroxylicious
 - add/update tests
 - centralize blank dynamic_key_id_prefix validation in core

 Behavior

 If a configured key identifier starts with dynamic_key_id_prefix (default __#), the suffix is treated as a field path and resolved at runtime from the input record/payload.

 Processing fails if the path:
 - is missing
 - resolves to a non-string value
 - resolves to a blank string